### PR TITLE
[FEAT] 상품 상세 페이지 디자인 (#7)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Shop } from './pages/Shop';
 import { Login } from './pages/Login';
 import { Cart } from './pages/Cart';
 import { MyPage } from './pages/MyPage';
+import { ProductDetailPage } from './pages/ProductDetailPage';
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Route element={<MainLayout />}>
           <Route path="/" element={<Home />} />
           <Route path="/shop" element={<Shop />} />
+          <Route path="/products/:id" element={<ProductDetailPage />} />
           <Route path="/login" element={<Login />} />
           <Route path="/cart" element={<Cart />} />
           <Route path="/mypage" element={<MyPage />} />

--- a/src/components/ProductCard.css
+++ b/src/components/ProductCard.css
@@ -1,4 +1,14 @@
 /* ProductCard Styles */
+.product-card-link {
+    display: block;
+    width: 250px;
+    /* Fixed width as requested */
+    text-decoration: none;
+    color: inherit;
+    margin: 0 auto;
+    /* Center in grid cell */
+}
+
 .product-card {
     display: flex;
     flex-direction: column;

--- a/src/components/ProductCard.css
+++ b/src/components/ProductCard.css
@@ -59,8 +59,11 @@
 
 /* ... */
 
+/* ... */
+
 .product-brand {
-    font-size: 13px;
+    font-size: 16.3px;
+    /* 1.5x of 13px */
     font-weight: 700;
     color: #333;
     /* Dark text */
@@ -70,36 +73,44 @@
 }
 
 .product-name {
-    font-size: 13px;
+    font-size: 17px;
+    /* 1.5x of 13px */
     color: #333;
     /* Dark text */
     line-height: 1.4;
     margin-bottom: 8px;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-    -webkit-box-orient: vertical;
+    white-space: nowrap;
     overflow: hidden;
-    height: 36px;
+    text-overflow: ellipsis;
+    display: block;
+    height: auto;
 }
 
 .product-price {
     margin-top: auto;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    /* Horizontal layout */
+    align-items: center;
+    /* Align vertically */
+    gap: 10px;
+    /* Space between label and price */
 }
 
 .price-amount {
-    font-size: 16px;
+    font-size: 16.5px;
+    /* 1.5x of 16px */
     font-weight: 700;
-    color: #000;
+    color: #333;
     /* Black price */
 }
 
 .price-label {
-    font-size: 11px;
+    font-size: 16.5px;
+    /* ~1.5x of 11px */
     color: #888;
-    margin-top: 2px;
+    margin-top: 0;
+    /* Remove top margin */
 }
 
 .product-image {
@@ -146,44 +157,4 @@
     flex-direction: column;
 }
 
-.product-brand {
-    font-size: 13px;
-    font-weight: 700;
-    color: #e0e0e0;
-    /* Light text for dark mode */
-    margin-bottom: 4px;
-    text-decoration: underline;
-    text-decoration-color: transparent;
-}
-
-.product-name {
-    font-size: 13px;
-    color: #b0b0b0;
-    line-height: 1.4;
-    margin-bottom: 8px;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    height: 36px;
-    /* Fixed height for alignment */
-}
-
-.product-price {
-    margin-top: auto;
-    display: flex;
-    flex-direction: column;
-}
-
-.price-amount {
-    font-size: 16px;
-    font-weight: 700;
-    color: #ffffff;
-}
-
-.price-label {
-    font-size: 11px;
-    color: #888;
-    margin-top: 2px;
-}
+/* Removed duplicated blocks (dark mode temporary styles) to clean up file */

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -32,8 +32,8 @@ export const ProductCard = ({ id, brand, name, price, imageUrl, tags }: ProductC
                         </div>
                     )}
                     <div className="product-price">
-                        <span className="price-amount">{price.toLocaleString()}원</span>
                         <span className="price-label">즉시 구매가</span>
+                        <span className="price-amount">{price.toLocaleString()}원</span>
                     </div>
                 </div>
             </div>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,5 +1,6 @@
 import './ProductCard.css';
 import { Heart } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 interface ProductCardProps {
     id: string;
@@ -10,30 +11,32 @@ interface ProductCardProps {
     tags?: string[];
 }
 
-export const ProductCard = ({ brand, name, price, imageUrl, tags }: ProductCardProps) => {
+export const ProductCard = ({ id, brand, name, price, imageUrl, tags }: ProductCardProps) => {
     return (
-        <div className="product-card">
-            <div className="product-image-container">
-                <img src={imageUrl} alt={name} className="product-image" />
-                <button className="wishlist-btn">
-                    <Heart size={18} color="#333" />
-                </button>
-            </div>
-            <div className="product-info">
-                <h4 className="product-brand">{brand}</h4>
-                <p className="product-name">{name}</p>
-                {tags && tags.length > 0 && (
-                    <div className="product-tags">
-                        {tags.map(tag => (
-                            <span key={tag} className="product-tag">{tag}</span>
-                        ))}
+        <Link to={`/products/${id}`} className="product-card-link">
+            <div className="product-card">
+                <div className="product-image-container">
+                    <img src={imageUrl} alt={name} className="product-image" />
+                    <button className="wishlist-btn" onClick={(e) => e.preventDefault()}>
+                        <Heart size={18} color="#333" />
+                    </button>
+                </div>
+                <div className="product-info">
+                    <h4 className="product-brand">{brand}</h4>
+                    <p className="product-name">{name}</p>
+                    {tags && tags.length > 0 && (
+                        <div className="product-tags">
+                            {tags.map(tag => (
+                                <span key={tag} className="product-tag">{tag}</span>
+                            ))}
+                        </div>
+                    )}
+                    <div className="product-price">
+                        <span className="price-amount">{price.toLocaleString()}원</span>
+                        <span className="price-label">즉시 구매가</span>
                     </div>
-                )}
-                <div className="product-price">
-                    <span className="price-amount">{price.toLocaleString()}원</span>
-                    <span className="price-label">즉시 구매가</span>
                 </div>
             </div>
-        </div>
+        </Link>
     );
 };

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,0 +1,19 @@
+export interface Product {
+    id: string;
+    brand: string;
+    name: string;
+    price: number;
+    imageUrl: string;
+    tags?: string[];
+}
+
+export const SHOP_PRODUCTS: Product[] = [
+    { id: '1', brand: 'Nike', name: 'Nike Air Force 1 \'07 White', price: 139000, imageUrl: 'https://placehold.co/400x400/png?text=Air+Force+1' },
+    { id: '2', brand: 'Adidas', name: 'Adidas Samba OG Cloud White', price: 150000, imageUrl: 'https://placehold.co/400x400/png?text=Samba' },
+    { id: '3', brand: 'Supreme', name: 'Supreme Box Logo Hoodie', price: 500000, imageUrl: 'https://placehold.co/400x400/png?text=Supreme' },
+    { id: '4', brand: 'New Balance', name: 'New Balance 530 Steel Grey', price: 129000, imageUrl: 'https://placehold.co/400x400/png?text=NB+530' },
+    { id: '5', brand: 'Nike', name: 'Nike Dunk Low Retro Black White', price: 129000, imageUrl: 'https://placehold.co/400x400/png?text=Dunk+Low' },
+    { id: '6', brand: 'Jordan', name: 'Jordan 1 Retro High OG', price: 239000, imageUrl: 'https://placehold.co/400x400/png?text=Jordan+1' },
+    { id: '7', brand: 'Stussy', name: 'Stussy World Tour Tee', price: 68000, imageUrl: 'https://placehold.co/400x400/png?text=Stussy' },
+    { id: '8', brand: 'Apple', name: 'AirPods Max Silver', price: 769000, imageUrl: 'https://placehold.co/400x400/png?text=AirPods' },
+];

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -199,15 +199,16 @@
 }
 
 .sidebar-cat-btn:hover {
-    background: #f5f5f5;
-    color: #000;
+    background: #fff0f0;
+    color: #ff6b6b;
 }
 
 .sidebar-cat-btn.active {
-    background: #000;
-    /* Black for View Category Active */
+    background: #ff6b6b;
+    /* Orange for Category Active */
     color: #fff;
     font-weight: 700;
+    box-shadow: 0 4px 10px rgba(255, 107, 107, 0.3);
 }
 
 /* Sidebar Brand Button */
@@ -328,17 +329,22 @@
     transition: background 0.2s;
 }
 
-color: #000;
-font-weight: 800;
-}
+
 
 
 /* Product Section Container */
 .section-container {
-    max-width: 1600px;
+    max-width: 100%;
     margin: 0 auto;
-    padding: 2rem 10%;
-    /* Large side padding for "blank space" */
+    padding: 2rem 40px;
+    /* Adjusted padding */
+}
+
+/* Home page specific: Use max-width and auto margin for centering instead of large padding */
+.home-page>.section-container {
+    max-width: 1500px;
+    margin: 0 auto;
+    padding: 2rem 40px;
 }
 
 .section-header {
@@ -363,9 +369,12 @@ font-weight: 800;
 
 .product-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    /* 4 items per row for Home */
+    grid-template-columns: repeat(auto-fill, 250px);
+    justify-content: center;
     gap: 20px;
+    max-width: 1350px;
+    /* 5 columns max */
+    margin: 0 auto;
 }
 
 /* Shop page grid override */
@@ -374,18 +383,12 @@ font-weight: 800;
 }
 
 @media (max-width: 1024px) {
-    .product-grid {
-        grid-template-columns: repeat(3, 1fr);
-    }
+    /* Auto-fill handles grid, removing explicit override */
 }
 
 @media (max-width: 768px) {
     .hero-title {
         font-size: 2.5rem;
-    }
-
-    .product-grid {
-        grid-template-columns: repeat(2, 1fr);
     }
 
     .nav {

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -352,14 +352,14 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: 2rem;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid darkgray;
     padding-bottom: 1rem;
 }
 
 .section-header h3 {
     font-size: 1.5rem;
     font-weight: 700;
-    color: #fff;
+    color: #333;
 }
 
 .section-count {

--- a/src/pages/ProductDetailPage.css
+++ b/src/pages/ProductDetailPage.css
@@ -111,13 +111,13 @@
 }
 
 .action-btn.buy {
-    background: linear-gradient(135deg, #FF6B6B 0%, #EE5D50 100%);
-    box-shadow: 0 4px 15px rgba(238, 93, 80, 0.3);
+    background: linear-gradient(135deg, #8e24aa 0%, #ab47bc 100%);
+    box-shadow: 0 4px 15px rgba(142, 36, 170, 0.3);
 }
 
 .action-btn.sell {
-    background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
-    box-shadow: 0 4px 15px rgba(79, 172, 254, 0.3);
+    background: linear-gradient(135deg, #5c6bc0 0%, #7986cb 100%);
+    box-shadow: 0 4px 15px rgba(92, 107, 192, 0.3);
 }
 
 .action-sub-text {

--- a/src/pages/ProductDetailPage.css
+++ b/src/pages/ProductDetailPage.css
@@ -1,7 +1,7 @@
 .product-detail-container {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 40px 20px;
+    padding: 140px 20px 300px;
     display: flex;
     gap: 60px;
 }
@@ -17,7 +17,8 @@
     background-color: #f4f4f4;
     border-radius: 12px;
     width: 100%;
-    padding-bottom: 100%; /* Square aspect ratio */
+    padding-bottom: 100%;
+    /* Square aspect ratio */
     position: relative;
     overflow: hidden;
 }
@@ -29,8 +30,9 @@
     transform: translate(-50%, -50%);
     width: 100%;
     height: 100%;
-    object-fit: cover; /* Cover usually looks better, but contain prevents cropping */
-    object-fit: contain; 
+    object-fit: cover;
+    /* Cover usually looks better, but contain prevents cropping */
+    object-fit: contain;
 }
 
 .product-detail-right {
@@ -57,7 +59,7 @@
 
 .detail-product-name-ko {
     font-size: 14px;
-    color: rgba(34,34,34,.5);
+    color: rgba(34, 34, 34, .5);
     margin-bottom: 20px;
 }
 
@@ -67,7 +69,7 @@
 
 .detail-price-label {
     font-size: 13px;
-    color: rgba(34,34,34,.8);
+    color: rgba(34, 34, 34, .8);
 }
 
 .detail-price-amount {
@@ -109,18 +111,20 @@
 }
 
 .action-btn.buy {
-    background-color: #ef6253;
+    background: linear-gradient(135deg, #FF6B6B 0%, #EE5D50 100%);
+    box-shadow: 0 4px 15px rgba(238, 93, 80, 0.3);
 }
 
 .action-btn.sell {
-    background-color: #41b979;
+    background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+    box-shadow: 0 4px 15px rgba(79, 172, 254, 0.3);
 }
 
 .action-sub-text {
     font-size: 11px;
     font-weight: 400;
     margin-top: 2px;
-    color: rgba(255,255,255,0.8);
+    color: rgba(255, 255, 255, 0.8);
 }
 
 .wishlist-btn-large {
@@ -180,7 +184,7 @@
 
 .delivery-desc {
     font-size: 13px;
-    color: rgba(34,34,34,.5);
+    color: rgba(34, 34, 34, .5);
     margin-top: 2px;
 }
 
@@ -189,7 +193,7 @@
         flex-direction: column;
         gap: 20px;
     }
-    
+
     .product-detail-left {
         position: static;
     }

--- a/src/pages/ProductDetailPage.css
+++ b/src/pages/ProductDetailPage.css
@@ -1,0 +1,196 @@
+.product-detail-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 40px 20px;
+    display: flex;
+    gap: 60px;
+}
+
+.product-detail-left {
+    flex: 1;
+    position: sticky;
+    top: 40px;
+    height: fit-content;
+}
+
+.product-detail-image-wrapper {
+    background-color: #f4f4f4;
+    border-radius: 12px;
+    width: 100%;
+    padding-bottom: 100%; /* Square aspect ratio */
+    position: relative;
+    overflow: hidden;
+}
+
+.product-detail-image {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
+    height: 100%;
+    object-fit: cover; /* Cover usually looks better, but contain prevents cropping */
+    object-fit: contain; 
+}
+
+.product-detail-right {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.detail-brand-name {
+    font-size: 18px;
+    font-weight: 700;
+    color: #333;
+    margin-bottom: 8px;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+}
+
+.detail-product-name {
+    font-size: 20px;
+    color: #000;
+    margin-bottom: 6px;
+    line-height: 1.4;
+}
+
+.detail-product-name-ko {
+    font-size: 14px;
+    color: rgba(34,34,34,.5);
+    margin-bottom: 20px;
+}
+
+.detail-price-section {
+    margin-bottom: 40px;
+}
+
+.detail-price-label {
+    font-size: 13px;
+    color: rgba(34,34,34,.8);
+}
+
+.detail-price-amount {
+    display: block;
+    font-size: 24px;
+    font-weight: 700;
+    margin-top: 4px;
+}
+
+.detail-price-unit {
+    font-size: 18px;
+    font-weight: 400;
+}
+
+.product-actions {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.action-btn {
+    flex: 1;
+    height: 60px;
+    border-radius: 12px;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    font-weight: 600;
+    transition: opacity 0.2s;
+}
+
+.action-btn:hover {
+    opacity: 0.9;
+}
+
+.action-btn.buy {
+    background-color: #ef6253;
+}
+
+.action-btn.sell {
+    background-color: #41b979;
+}
+
+.action-sub-text {
+    font-size: 11px;
+    font-weight: 400;
+    margin-top: 2px;
+    color: rgba(255,255,255,0.8);
+}
+
+.wishlist-btn-large {
+    width: 100%;
+    height: 50px;
+    border: 1px solid #d3d3d3;
+    background: #fff;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 16px;
+    cursor: pointer;
+    transition: all 0.2s;
+    margin-bottom: 30px;
+}
+
+.wishlist-btn-large:hover {
+    background-color: #fafafa;
+}
+
+.delivery-info {
+    margin-top: 20px;
+    border-top: 1px solid #ebebeb;
+    padding-top: 20px;
+}
+
+.delivery-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 15px;
+    margin-bottom: 15px;
+}
+
+.delivery-icon {
+    width: 40px;
+    height: 40px;
+    background-color: #f4f4f4;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #666;
+    flex-shrink: 0;
+}
+
+.delivery-text p {
+    margin: 0;
+}
+
+.delivery-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #222;
+}
+
+.delivery-desc {
+    font-size: 13px;
+    color: rgba(34,34,34,.5);
+    margin-top: 2px;
+}
+
+@media (max-width: 768px) {
+    .product-detail-container {
+        flex-direction: column;
+        gap: 20px;
+    }
+    
+    .product-detail-left {
+        position: static;
+    }
+}

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -1,0 +1,78 @@
+import { useParams, Link } from 'react-router-dom';
+import { SHOP_PRODUCTS } from '../data/mockData';
+import { Heart, Truck, CheckCircle } from 'lucide-react';
+import './ProductDetailPage.css';
+
+export const ProductDetailPage = () => {
+    const { id } = useParams<{ id: string }>();
+    const product = SHOP_PRODUCTS.find(p => p.id === id);
+
+    if (!product) {
+        return (
+            <div className="product-not-found">
+                <h2>상품을 찾을 수 없습니다.</h2>
+                <Link to="/shop">Shop으로 돌아가기</Link>
+            </div>
+        );
+    }
+
+    return (
+        <div className="product-detail-container">
+            <div className="product-detail-left">
+                <div className="product-detail-image-wrapper">
+                    <img src={product.imageUrl} alt={product.name} className="product-detail-image" />
+                </div>
+            </div>
+
+            <div className="product-detail-right">
+                <div className="product-info-header">
+                    <a href="#" className="detail-brand-name">{product.brand}</a>
+                    <h1 className="detail-product-name">{product.name}</h1>
+                    <p className="detail-product-name-ko">{product.name} (한글명 없음)</p> {/* Mock data doesn't have KO name */}
+                </div>
+
+                <div className="detail-price-section">
+                    <span className="detail-price-label">최근 거래가</span>
+                    <strong className="detail-price-amount">{product.price.toLocaleString()}<span className="detail-price-unit">원</span></strong>
+                </div>
+
+                <div className="product-actions">
+                    <button className="action-btn buy">
+                        구매
+                        <span className="action-sub-text">즉시 구매가</span>
+                    </button>
+                    <button className="action-btn sell">
+                        판매
+                        <span className="action-sub-text">즉시 판매가</span>
+                    </button>
+                </div>
+
+                <button className="wishlist-btn-large">
+                    <Heart size={20} />
+                    <span>관심상품</span>
+                </button>
+
+                <div className="delivery-info">
+                    <div className="delivery-item">
+                        <div className="delivery-icon">
+                            <Truck size={20} />
+                        </div>
+                        <div className="delivery-text">
+                            <p className="delivery-title">무료배송</p>
+                            <p className="delivery-desc">모든 상품 무료 배송 (이벤트 기간)</p>
+                        </div>
+                    </div>
+                    <div className="delivery-item">
+                        <div className="delivery-icon">
+                            <CheckCircle size={20} />
+                        </div>
+                        <div className="delivery-text">
+                            <p className="delivery-title">정품 보증</p>
+                            <p className="delivery-desc">KREAM 검수센터에서 검수 후 배송</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { SHOP_PRODUCTS } from '../data/mockData';
 import { Heart, Truck, CheckCircle } from 'lucide-react';
@@ -6,6 +7,11 @@ import './ProductDetailPage.css';
 export const ProductDetailPage = () => {
     const { id } = useParams<{ id: string }>();
     const product = SHOP_PRODUCTS.find(p => p.id === id);
+    const [isWishlisted, setIsWishlisted] = useState(false);
+
+    const toggleWishlist = () => {
+        setIsWishlisted(!isWishlisted);
+    };
 
     if (!product) {
         return (
@@ -47,9 +53,9 @@ export const ProductDetailPage = () => {
                     </button>
                 </div>
 
-                <button className="wishlist-btn-large">
-                    <Heart size={20} />
-                    <span>관심상품</span>
+                <button className="wishlist-btn-large" onClick={toggleWishlist}>
+                    <Heart size={20} fill={isWishlisted ? "#333" : "none"} />
+                    <span>{isWishlisted ? "관심상품 추가됨" : "관심상품"}</span>
                 </button>
 
                 <div className="delivery-info">
@@ -58,8 +64,8 @@ export const ProductDetailPage = () => {
                             <Truck size={20} />
                         </div>
                         <div className="delivery-text">
-                            <p className="delivery-title">무료배송</p>
-                            <p className="delivery-desc">모든 상품 무료 배송 (이벤트 기간)</p>
+                            <p className="delivery-title">배송비 3,000원</p>
+                            <p className="delivery-desc">검수 완료 후 배송</p>
                         </div>
                     </div>
                     <div className="delivery-item">
@@ -68,7 +74,7 @@ export const ProductDetailPage = () => {
                         </div>
                         <div className="delivery-text">
                             <p className="delivery-title">정품 보증</p>
-                            <p className="delivery-desc">KREAM 검수센터에서 검수 후 배송</p>
+                            <p className="delivery-desc">RESELLO 검수센터에서 검수 후 배송</p>
                         </div>
                     </div>
                 </div>

--- a/src/pages/Shop.css
+++ b/src/pages/Shop.css
@@ -1,6 +1,7 @@
 /* Shop Styles */
 .shop-container {
-    max-width: var(--container-width);
+    max-width: 100%;
+    /* Unlock width to allow more columns */
     margin: 0 auto;
     padding: var(--spacing-xl) var(--spacing-md);
     display: flex;
@@ -11,6 +12,21 @@
     width: 200px;
     flex-shrink: 0;
 }
+
+/* ... existing styles ... */
+
+/* Higher specificity to override Home.css */
+.product-grid.shop-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 250px);
+    justify-content: center;
+    gap: 20px;
+    max-width: 1350px;
+    /* Limit to 5 columns max */
+    margin: 0 auto;
+}
+
+/* Removed conflicting media query forcing 2 columns */
 
 .filter-section {
     margin-bottom: var(--spacing-xl);
@@ -55,12 +71,14 @@
 }
 
 /* Reuse product grid but verify specificity */
-.shop-grid {
-    grid-template-columns: repeat(3, 1fr);
+/* Sidebar Styles from Shop.tsx */
+.sidebar-section {
+    margin-bottom: 40px;
 }
 
-@media (max-width: 1024px) {
-    .shop-grid {
-        grid-template-columns: repeat(2, 1fr);
-    }
+.sidebar-title {
+    font-size: 16px;
+    font-weight: 700;
+    margin-bottom: 16px;
+    color: #000;
 }

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -4,16 +4,7 @@ import { Search } from 'lucide-react';
 import './Shop.css';
 import '../pages/Home.css'; // Reuse Home structure styles
 
-const SHOP_PRODUCTS = [
-    { id: '1', brand: 'Nike', name: 'Nike Air Force 1 \'07 White', price: 139000, imageUrl: 'https://placehold.co/400x400/png?text=Air+Force+1' },
-    { id: '2', brand: 'Adidas', name: 'Adidas Samba OG Cloud White', price: 150000, imageUrl: 'https://placehold.co/400x400/png?text=Samba' },
-    { id: '3', brand: 'Supreme', name: 'Supreme Box Logo Hoodie', price: 500000, imageUrl: 'https://placehold.co/400x400/png?text=Supreme' },
-    { id: '4', brand: 'New Balance', name: 'New Balance 530 Steel Grey', price: 129000, imageUrl: 'https://placehold.co/400x400/png?text=NB+530' },
-    { id: '5', brand: 'Nike', name: 'Nike Dunk Low Retro Black White', price: 129000, imageUrl: 'https://placehold.co/400x400/png?text=Dunk+Low' },
-    { id: '6', brand: 'Jordan', name: 'Jordan 1 Retro High OG', price: 239000, imageUrl: 'https://placehold.co/400x400/png?text=Jordan+1' },
-    { id: '7', brand: 'Stussy', name: 'Stussy World Tour Tee', price: 68000, imageUrl: 'https://placehold.co/400x400/png?text=Stussy' },
-    { id: '8', brand: 'Apple', name: 'AirPods Max Silver', price: 769000, imageUrl: 'https://placehold.co/400x400/png?text=AirPods' },
-];
+import { SHOP_PRODUCTS } from '../data/mockData';
 
 const CATEGORIES = ["전체", "스니커즈", "의류", "액세서리", "컬렉터블"];
 

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -79,7 +79,7 @@ export const Shop = () => {
                         <h3>전체 상품</h3>
                         <span className="section-count">{SHOP_PRODUCTS.length}개 상품</span>
                     </div>
-                    <div className="product-grid">
+                    <div className="product-grid shop-grid">
                         {SHOP_PRODUCTS.map(product => (
                             <ProductCard key={product.id} {...product} />
                         ))}


### PR DESCRIPTION
### 작업내용
- 메인 페이지에서 쇼핑 메뉴 진입했을 때 상품 목록 페이지 디자인 수정
   - 상품 목록 그리드 가로 개수를 최대 5개로 고정, 왼/오 여백 조정
   - 상품 카테고리, 브랜드 선택 메뉴 디자인 통일되지 않아있던 것 통일
- 메인 페이지 상품 목록 그리드 수정
  -  상품 목록 그리드 가로 개수를 최대 5개로 고정, 왼/오 여백 조정
- 상품 상세 보기 페이지 추가
- 상품 카드의 폰트 크기 조정

<img width="2030" height="1104" alt="image" src="https://github.com/user-attachments/assets/334ccf4f-6d2d-4b98-bb8c-1865e3159ca6" />
<br>
<img width="2032" height="1105" alt="image" src="https://github.com/user-attachments/assets/f1701cb5-86dc-43fd-94cc-b711c3f85065" />
<br>
<img width="2528" height="1261" alt="image" src="https://github.com/user-attachments/assets/3b1f349f-963d-48e5-b716-997b6c99bb15" />
<br>
<img width="1439" height="903" alt="image" src="https://github.com/user-attachments/assets/e7372d0e-f7bb-4763-af8b-0c7f28516f49" />
<br>
