### PR TITLE
[FEAT] 헤더 디자인 변경과 장바구니 관련 추가 구현 (#17)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { ShoppingCart, Package, User, Bell, Menu, X } from 'lucide-react';
 import { Logo } from './Logo';
 import { useAuthStore } from '../store/authStore';
+import { useCartStore } from '../store/cartStore';
+import { useWishlistStore } from '../store/useWishlistStore';
 import { logout } from '../api/auth';
 
 const INITIAL_NOTIFICATIONS = [
@@ -85,9 +87,13 @@ export const Header = () => {
     const notifContainerRef = useRef<HTMLDivElement>(null);
     const mobileMenuRef = useRef<HTMLDivElement>(null);
     const { isAuthenticated } = useAuthStore();
+    const { clearCart } = useCartStore();
+    const { clearWishlist } = useWishlistStore();
 
     const handleLogout = async () => {
         await logout();
+        clearCart();
+        clearWishlist();
         window.location.href = '/';
     };
 

--- a/src/components/HeaderV2.tsx
+++ b/src/components/HeaderV2.tsx
@@ -1,0 +1,256 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { ShoppingCart, Package, User, Bell, Menu, X, Search } from 'lucide-react';
+import { Logo } from './Logo';
+import { useAuthStore } from '../store/authStore';
+import { useCartStore } from '../store/cartStore';
+import { logout } from '../api/auth';
+
+const INITIAL_NOTIFICATIONS = [
+    { id: 1, text: "관심 상품 <strong>조던 1 시카고</strong>의 가격이 하락했습니다.", time: "방금 전", unread: true },
+    { id: 2, text: "새로운 스타일 챌린지가 시작되었습니다!", time: "1시간 전", unread: false },
+    { id: 3, text: "배송이 시작되었습니다.", time: "어제", unread: false },
+    { id: 4, text: "관심 상품 <strong>나이키 덩크 로우</strong> 재입고 알림", time: "2일 전", unread: false },
+    { id: 5, text: "회원 등급이 상향 조정되었습니다.", time: "3일 전", unread: false },
+];
+
+const NotificationDropdown = () => {
+    const [notifications, setNotifications] = useState(INITIAL_NOTIFICATIONS);
+    const [loading, setLoading] = useState(false);
+    const listRef = useRef<HTMLDivElement>(null);
+
+    const loadMoreNotifications = useCallback(() => {
+        if (loading || notifications.length >= 15) return;
+        setLoading(true);
+
+        setTimeout(() => {
+            const currentLength = notifications.length;
+            const moreNotifications = Array.from({ length: 3 }).map((_, i) => ({
+                id: currentLength + i + 1,
+                text: `이전 알림 내용입니다. #${currentLength + i + 1}`,
+                time: `${currentLength + i}일 전`,
+                unread: false
+            }));
+
+            setNotifications(prev => [...prev, ...moreNotifications]);
+            setLoading(false);
+        }, 800);
+    }, [loading, notifications.length]);
+
+    const handleScroll = () => {
+        const list = listRef.current;
+        if (list) {
+            const { scrollTop, scrollHeight, clientHeight } = list;
+            if (scrollTop + clientHeight >= scrollHeight - 20) {
+                loadMoreNotifications();
+            }
+        }
+    };
+
+    return (
+        <div className="absolute top-[120%] right-0 w-[380px] bg-white/90 backdrop-blur-xl rounded-2xl shadow-[0_20px_50px_rgba(0,0,0,0.15)] overflow-hidden border border-white/20 origin-top-right animate-in fade-in zoom-in duration-300 z-[1001]">
+            <div className="p-4 px-5 flex justify-between items-center border-b border-gray-100">
+                <span className="text-sm font-bold text-gray-900">알림</span>
+                <span className="text-xs text-gray-500 cursor-pointer font-medium hover:text-black">모두 읽음</span>
+            </div>
+            <div className="max-h-[400px] overflow-y-auto scrollbar-hide" ref={listRef} onScroll={handleScroll}>
+                {notifications.map((notif) => (
+                    <div key={notif.id} className={`p-4 px-5 border-b border-gray-50 transition-all cursor-pointer hover:bg-black/5 ${notif.unread ? 'bg-indigo-50/50' : ''}`}>
+                        <div className="flex gap-3">
+                            {notif.unread && <div className="w-2 h-2 rounded-full bg-indigo-600 mt-1.5 flex-shrink-0" />}
+                            <div>
+                                <p className="text-[13px] text-gray-800 leading-snug mb-1" dangerouslySetInnerHTML={{ __html: notif.text }}></p>
+                                <span className="text-[11px] text-gray-400 font-medium">{notif.time}</span>
+                            </div>
+                        </div>
+                    </div>
+                ))}
+                {loading && <div className="p-4 text-center text-gray-400 text-xs">불러오는 중...</div>}
+            </div>
+        </div>
+    );
+};
+
+export const HeaderV2 = () => {
+    const [showNotifications, setShowNotifications] = useState(false);
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const [isScrolled, setIsScrolled] = useState(false);
+    const notifContainerRef = useRef<HTMLDivElement>(null);
+    const mobileMenuRef = useRef<HTMLDivElement>(null);
+    const { isAuthenticated } = useAuthStore();
+    const { cartItems } = useCartStore();
+
+    const handleLogout = async () => {
+        await logout();
+        window.location.href = '/';
+    };
+
+    useEffect(() => {
+        const handleResize = () => {
+            if (window.innerWidth >= 1024) {
+                setIsMobileMenuOpen(false);
+            }
+        };
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    useEffect(() => {
+        const handleScroll = () => {
+            setIsScrolled(window.scrollY > 20);
+        };
+        window.addEventListener('scroll', handleScroll);
+        return () => window.removeEventListener('scroll', handleScroll);
+    }, []);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (notifContainerRef.current && !notifContainerRef.current.contains(event.target as Node)) {
+                setShowNotifications(false);
+            }
+            if (mobileMenuRef.current && !mobileMenuRef.current.contains(event.target as Node)) {
+                setIsMobileMenuOpen(false);
+            }
+        };
+
+        if (showNotifications || isMobileMenuOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [showNotifications, isMobileMenuOpen]);
+
+    return (
+        <header
+            className={`fixed top-0 left-0 right-0 z-[1000] transition-all duration-500 border-b ${isScrolled
+                ? 'bg-white/80 backdrop-blur-md py-3 border-gray-100 shadow-sm'
+                : 'bg-transparent py-5 border-transparent'
+                }`}
+        >
+            <div className="max-w-[1440px] mx-auto px-6 md:px-10 flex justify-between items-center">
+                {/* Logo Section */}
+                <div className="flex items-center gap-12">
+                    <Link to="/" className="flex-shrink-0 group transition-transform hover:scale-105 active:scale-95">
+                        <Logo size="lg" />
+                    </Link>
+
+                    {/* Desktop Navigation */}
+                    <nav className="hidden lg:flex items-center gap-2">
+                        {['HOME', 'SHOP', 'STYLE', 'SAVED'].map((item) => (
+                            <Link
+                                key={item}
+                                to={item === 'HOME' ? '/' : `/${item.toLowerCase()}`}
+                                className="relative text-[13px] font-bold tracking-widest text-gray-900 px-4 py-2 rounded-full transition-all duration-300 hover:bg-black/5 hover:text-[#3949ab] group"
+                            >
+                                {item}
+                            </Link>
+                        ))}
+                    </nav>
+                </div>
+
+                {/* Right Actions */}
+                <div className="flex items-center gap-2 md:gap-4">
+                    {/* Search Bar (Desktop) */}
+                    <div className="hidden md:flex items-center bg-black/5 hover:bg-black/10 rounded-full px-4 py-2 transition-colors cursor-pointer group">
+                        <Search size={18} className="text-gray-500 group-hover:text-black transition-colors" />
+                        <input
+                            type="text"
+                            placeholder="Search trends..."
+                            className="bg-transparent border-none outline-none ml-2 text-sm w-32 focus:w-48 transition-all duration-300"
+                        />
+                    </div>
+
+                    <div className="flex items-center gap-1 md:gap-3 relative" ref={notifContainerRef}>
+                        {/* Notifications */}
+                        <button
+                            onClick={() => setShowNotifications(!showNotifications)}
+                            className="p-2.5 rounded-full hover:bg-black/5 transition-colors relative"
+                        >
+                            <Bell size={20} strokeWidth={2.5} />
+                            <span className="absolute top-2 right-2 w-2 h-2 bg-indigo-600 rounded-full border-2 border-white" />
+                        </button>
+
+                        {showNotifications && <NotificationDropdown />}
+
+                        <Link to="/mypage?tab=delivery" className="p-2.5 rounded-full hover:bg-black/5 transition-colors hidden sm:block">
+                            <Package size={20} strokeWidth={2.5} />
+                        </Link>
+
+                        <Link to="/mypage?tab=profile" className="p-2.5 rounded-full hover:bg-black/5 transition-colors hidden sm:block">
+                            <User size={20} strokeWidth={2.5} />
+                        </Link>
+
+                        <Link to="/cart" className="p-2.5 rounded-full hover:bg-black/5 transition-colors relative">
+                            <ShoppingCart size={20} strokeWidth={2.5} />
+                            {cartItems.length > 0 && (
+                                <span className="absolute top-1 -right-0.5 bg-black text-white text-[10px] font-bold px-1 min-w-[16px] h-4 rounded-full flex items-center justify-center">
+                                    {cartItems.length}
+                                </span>
+                            )}
+                        </Link>
+
+                        {isAuthenticated ? (
+                            <button
+                                onClick={handleLogout}
+                                className="hidden md:block text-[13px] font-bold px-5 py-2 hover:text-indigo-600 transition-colors"
+                            >
+                                LOGOUT
+                            </button>
+                        ) : (
+                            <Link
+                                to="/login"
+                                className="hidden md:block bg-accent text-white px-6 py-2.5 rounded-full text-[13px] font-bold hover:bg-[#3949ab] transition-all active:scale-95"
+                            >
+                                LOGIN
+                            </Link>
+                        )}
+                        {/* Mobile Menu Toggle */}
+                        <button
+                            className="lg:hidden p-2 text-gray-900"
+                            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                        >
+                            {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            {/* Mobile Menu Overlay */}
+            {isMobileMenuOpen && (
+                <div
+                    ref={mobileMenuRef}
+                    className="absolute top-full left-0 right-0 bg-white shadow-2xl border-t border-gray-50 flex flex-col p-8 z-[999] animate-in slide-in-from-top duration-300"
+                >
+                    <nav className="flex flex-col gap-6 mb-8">
+                        {['HOME', 'SHOP', 'STYLE', 'SAVED'].map((item) => (
+                            <Link
+                                key={item}
+                                to={item === 'HOME' ? '/' : `/${item.toLowerCase()}`}
+                                className="text-2xl font-bold text-gray-900"
+                                onClick={() => setIsMobileMenuOpen(false)}
+                            >
+                                {item}
+                            </Link>
+                        ))}
+                    </nav>
+
+                    <div className="grid grid-cols-2 gap-4 mt-auto border-t border-gray-100 pt-8">
+                        <Link to="/mypage?tab=profile" className="flex items-center gap-3 font-bold text-gray-600" onClick={() => setIsMobileMenuOpen(false)}>
+                            <User size={20} /> MY PAGE
+                        </Link>
+                        <Link to="/cart" className="flex items-center gap-3 font-bold text-gray-600" onClick={() => setIsMobileMenuOpen(false)}>
+                            <ShoppingCart size={20} /> CART
+                        </Link>
+                        <div className="flex items-center gap-3 font-bold text-gray-600 cursor-pointer" onClick={() => { setIsMobileMenuOpen(false); /* Add delivery logic later */ }}>
+                            <Package size={20} /> DELIVERY
+                        </div>
+                        {isAuthenticated ? (
+                            <button onClick={handleLogout} className="col-span-2 bg-gray-100 p-4 rounded-xl font-bold mt-4">LOGOUT</button>
+                        ) : (
+                            <Link to="/login" className="col-span-2 bg-accent text-white p-4 rounded-xl font-bold text-center mt-4 hover:bg-[#3949ab] transition-colors">LOGIN</Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </header>
+    );
+};

--- a/src/components/HeaderV2.tsx
+++ b/src/components/HeaderV2.tsx
@@ -4,6 +4,7 @@ import { ShoppingCart, Package, User, Bell, Menu, X, Search } from 'lucide-react
 import { Logo } from './Logo';
 import { useAuthStore } from '../store/authStore';
 import { useCartStore } from '../store/cartStore';
+import { useWishlistStore } from '../store/useWishlistStore';
 import { logout } from '../api/auth';
 
 const INITIAL_NOTIFICATIONS = [
@@ -78,10 +79,13 @@ export const HeaderV2 = () => {
     const notifContainerRef = useRef<HTMLDivElement>(null);
     const mobileMenuRef = useRef<HTMLDivElement>(null);
     const { isAuthenticated } = useAuthStore();
-    const { cartItems } = useCartStore();
+    const { cartItems, clearCart } = useCartStore();
+    const { clearWishlist } = useWishlistStore();
 
     const handleLogout = async () => {
         await logout();
+        clearCart();
+        clearWishlist();
         window.location.href = '/';
     };
 

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,12 +1,12 @@
 import { Outlet } from 'react-router-dom';
-import { Header } from '../components/Header';
+import { HeaderV2 } from '../components/HeaderV2';
 import { Footer } from '../components/Footer';
 
 
 export const MainLayout = () => {
     return (
         <div className="layout">
-            <Header />
+            <HeaderV2 />
             <main className="main-content">
                 <Outlet />
             </main>

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,58 +1,14 @@
-import { useState } from 'react';
 import { X, ShoppingBag } from 'lucide-react';
-
-interface CartItem {
-    id: string;
-    brand: string;
-    name: string;
-    size: string;
-    price: number;
-    imageUrl: string;
-    selected: boolean;
-}
-
-const INITIAL_CART_ITEMS: CartItem[] = [
-    {
-        id: '1',
-        brand: 'Nike',
-        name: 'Nike Air Jordan 1 Retro High OG Chicago',
-        size: '270',
-        price: 450000,
-        imageUrl: 'https://placehold.co/400x400/png?text=Jordan+1+Chicago',
-        selected: true
-    },
-    {
-        id: '2',
-        brand: 'Supreme',
-        name: 'Supreme Box Logo Hoodie Black',
-        size: 'L',
-        price: 850000,
-        imageUrl: 'https://placehold.co/400x400/png?text=Supreme+Box+Logo',
-        selected: true
-    },
-];
+import { useCartStore } from '../store/cartStore';
 
 export const Cart = () => {
-    const [cartItems, setCartItems] = useState<CartItem[]>(INITIAL_CART_ITEMS);
-
-    const toggleSelect = (id: string) => {
-        setCartItems(prev => prev.map(item =>
-            item.id === id ? { ...item, selected: !item.selected } : item
-        ));
-    };
-
-    const toggleSelectAll = () => {
-        const allSelected = cartItems.length > 0 && cartItems.every(item => item.selected);
-        setCartItems(prev => prev.map(item => ({ ...item, selected: !allSelected })));
-    };
-
-    const removeItem = (id: string) => {
-        setCartItems(prev => prev.filter(item => item.id !== id));
-    };
-
-    const removeSelectedItems = () => {
-        setCartItems(prev => prev.filter(item => !item.selected));
-    };
+    const {
+        cartItems,
+        toggleSelect,
+        toggleSelectAll,
+        removeItem,
+        removeSelectedItems
+    } = useCartStore();
 
     const selectedItems = cartItems.filter(item => item.selected);
     const productAmount = selectedItems.reduce((sum, item) => sum + item.price, 0);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -40,7 +40,7 @@ export const Home = () => {
             </section>
 
             {/* Category Navigation */}
-            <div className="sticky top-[70px] z-[50] border-b border-[#eee] bg-white py-4">
+            <div className="sticky top-[60px] z-[50] border-b border-[#eee] bg-white py-4">
                 <ul className="flex justify-center gap-4 m-0 p-0 list-none">
                     {CATEGORIES.map(cat => (
                         <li key={cat}>

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -1,14 +1,21 @@
 import { useEffect, useState } from 'react';
-import { useWishlistStore } from '../store/useWishlistStore';
 import { useParams, Link } from 'react-router-dom';
+import { useWishlistStore } from '../store/useWishlistStore';
 import { SHOP_PRODUCTS } from '../data/mockData';
-import { Heart, Truck, CheckCircle, Share2, Info, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useCartStore } from '../store/cartStore';
+import { Heart, Truck, CheckCircle, Share2, Info, ChevronLeft, ChevronRight, ShoppingCart, X } from 'lucide-react';
+
+const SIZE_OPTIONS = ["230", "240", "250", "260", "270", "280", "290"];
 
 export const ProductDetailPage = () => {
     const { id } = useParams<{ id: string }>();
     const product = SHOP_PRODUCTS.find(p => p.id === id);
     const { toggleWishlist, wishlistIds } = useWishlistStore();
+    const { addItem } = useCartStore();
     const [currentIndex, setCurrentIndex] = useState(0);
+    const [isSizeModalOpen, setIsSizeModalOpen] = useState(false);
+    const [selectedSize, setSelectedSize] = useState<string | null>(null);
+    const [showToast, setShowToast] = useState(false);
 
     const images = product?.images || [product?.imageUrl || ''];
 
@@ -31,6 +38,44 @@ export const ProductDetailPage = () => {
 
     const handleToggleWishlist = () => {
         if (id) toggleWishlist(id);
+    };
+
+    const handleAddToCart = () => {
+        if (!selectedSize) {
+            setIsSizeModalOpen(true);
+            return;
+        }
+
+        if (product) {
+            addItem({
+                id: `${product.id}-${selectedSize}`,
+                brand: product.brand,
+                name: product.name,
+                price: product.price,
+                imageUrl: product.imageUrl,
+                size: selectedSize
+            });
+            setShowToast(true);
+            setTimeout(() => setShowToast(false), 3000);
+        }
+    };
+
+    const confirmSizeAndAdd = (size: string) => {
+        setSelectedSize(size);
+        setIsSizeModalOpen(false);
+
+        if (product) {
+            addItem({
+                id: `${product.id}-${size}`,
+                brand: product.brand,
+                name: product.name,
+                price: product.price,
+                imageUrl: product.imageUrl,
+                size: size
+            });
+            setShowToast(true);
+            setTimeout(() => setShowToast(false), 3000);
+        }
     };
 
     if (!product) {
@@ -142,17 +187,72 @@ export const ProductDetailPage = () => {
                                 </button>
                             </div>
 
-                            <button
-                                className="w-full h-14 rounded-xl border border-solid border-gray-200 bg-white flex items-center justify-center gap-2 transition-all font-bold text-[#333] hover:border-gray-300 active:scale-[0.99]"
-                                onClick={handleToggleWishlist}
-                            >
-                                <Heart
-                                    size={20}
-                                    className={isWishlisted ? "text-red-500 fill-red-500" : "text-gray-300"}
-                                />
-                                <span>{isWishlisted ? "관심 상품 등록됨" : "관심 상품"}</span>
-                            </button>
+                            <div className="grid grid-cols-2 gap-4 mb-4">
+                                <button
+                                    className="w-full h-14 rounded-xl border border-solid border-gray-200 bg-white flex items-center justify-center gap-2 transition-all font-bold text-[#333] hover:border-gray-300 active:scale-[0.99]"
+                                    onClick={handleToggleWishlist}
+                                >
+                                    <Heart
+                                        size={20}
+                                        className={isWishlisted ? "text-red-500 fill-red-500" : "text-gray-300"}
+                                    />
+                                    <span>{isWishlisted ? "관심 상품" : "관심 등록"}</span>
+                                </button>
+                                <button
+                                    className="w-full h-14 rounded-xl border border-solid border-gray-200 bg-white flex items-center justify-center gap-2 transition-all font-bold text-[#333] hover:border-gray-300 active:scale-[0.99]"
+                                    onClick={handleAddToCart}
+                                >
+                                    <ShoppingCart size={20} className="text-gray-400" />
+                                    <span>장바구니 담기</span>
+                                </button>
+                            </div>
                         </div>
+
+                        {/* Size Selection Modal */}
+                        {isSizeModalOpen && (
+                            <div className="fixed inset-0 z-[2000] flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm p-4 animate-in fade-in duration-300" onClick={() => setIsSizeModalOpen(false)}>
+                                <div
+                                    className="bg-white w-full max-w-[480px] rounded-t-[32px] sm:rounded-[32px] overflow-hidden animate-in slide-in-from-bottom duration-500 shadow-2xl"
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    <div className="p-8">
+                                        <div className="flex justify-between items-center mb-8">
+                                            <h3 className="text-xl font-bold text-[#333]">사이즈 선택</h3>
+                                            <button onClick={() => setIsSizeModalOpen(false)} className="p-2 hover:bg-gray-100 rounded-full transition-colors text-gray-400">
+                                                <X size={24} />
+                                            </button>
+                                        </div>
+                                        <div className="grid grid-cols-3 gap-3">
+                                            {SIZE_OPTIONS.map(size => (
+                                                <button
+                                                    key={size}
+                                                    onClick={() => confirmSizeAndAdd(size)}
+                                                    className={`h-14 rounded-xl border border-solid transition-all font-bold text-sm
+                                                        ${selectedSize === size
+                                                            ? 'border-accent bg-accent text-white shadow-lg shadow-accent/20'
+                                                            : 'border-gray-100 bg-[#F9F9F9] text-gray-600 hover:border-gray-300 hover:bg-white'}
+                                                    `}
+                                                >
+                                                    {size}
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </div>
+                                    <div className="bg-gray-50 p-6 text-center">
+                                        <p className="text-xs text-gray-400 font-medium">사이즈를 선택하면 장바구니에 자동으로 담깁니다.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Success Toast */}
+                        {showToast && (
+                            <div className="fixed bottom-10 left-1/2 -translate-x-1/2 z-[3000] bg-gray-900 text-white px-8 py-4 rounded-full shadow-2xl flex items-center gap-3 animate-in fade-in slide-in-from-bottom-4 duration-300 font-bold text-sm">
+                                <CheckCircle size={18} className="text-green-400" />
+                                <span>장바구니에 상품을 담았습니다.</span>
+                                <Link to="/cart" className="ml-4 text-accent hover:underline">장바구니 이동</Link>
+                            </div>
+                        )}
 
                         <div className="space-y-6 pt-6 border-t border-solid border-gray-100">
                             <h4 className="text-sm font-black text-[#333] uppercase lg:text-base">배송 정보</h4>

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -16,7 +16,7 @@ export const Shop = () => {
     return (
         <div className="min-h-screen bg-white">
             {/* Search Section */}
-            <div className="pt-[100px] pb-10 bg-white border-b border-[#f0f0f0]">
+            <div className="pt-[80px] pb-10 bg-white border-b border-[#f0f0f0]">
                 <SearchBar />
             </div>
 

--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -1,0 +1,73 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface CartItem {
+    id: string;
+    brand: string;
+    name: string;
+    size: string;
+    price: number;
+    imageUrl: string;
+    selected: boolean;
+}
+
+interface CartState {
+    cartItems: CartItem[];
+    addItem: (item: Omit<CartItem, 'selected'>) => void;
+    removeItem: (id: string) => void;
+    removeSelectedItems: () => void;
+    toggleSelect: (id: string) => void;
+    toggleSelectAll: () => void;
+    clearCart: () => void;
+}
+
+export const useCartStore = create<CartState>()(
+    persist(
+        (set) => ({
+            cartItems: [
+                {
+                    id: '1',
+                    brand: 'Nike',
+                    name: 'Nike Air Jordan 1 Retro High OG Chicago',
+                    size: '270',
+                    price: 450000,
+                    imageUrl: 'https://placehold.co/400x400/png?text=Jordan+1+Chicago',
+                    selected: true
+                },
+                {
+                    id: '2',
+                    brand: 'Supreme',
+                    name: 'Supreme Box Logo Hoodie Black',
+                    size: 'L',
+                    price: 850000,
+                    imageUrl: 'https://placehold.co/400x400/png?text=Supreme+Box+Logo',
+                    selected: true
+                },
+            ],
+            addItem: (item) => set((state) => ({
+                cartItems: [...state.cartItems, { ...item, selected: true }]
+            })),
+            removeItem: (id) => set((state) => ({
+                cartItems: state.cartItems.filter((i) => i.id !== id)
+            })),
+            removeSelectedItems: () => set((state) => ({
+                cartItems: state.cartItems.filter((i) => !i.selected)
+            })),
+            toggleSelect: (id) => set((state) => ({
+                cartItems: state.cartItems.map((i) =>
+                    i.id === id ? { ...i, selected: !i.selected } : i
+                )
+            })),
+            toggleSelectAll: () => set((state) => {
+                const allSelected = state.cartItems.length > 0 && state.cartItems.every(i => i.selected);
+                return {
+                    cartItems: state.cartItems.map(i => ({ ...i, selected: !allSelected }))
+                };
+            }),
+            clearCart: () => set({ cartItems: [] }),
+        }),
+        {
+            name: 'cart-storage',
+        }
+    )
+);

--- a/src/store/useWishlistStore.ts
+++ b/src/store/useWishlistStore.ts
@@ -5,6 +5,7 @@ interface WishlistState {
     wishlistIds: string[];
     toggleWishlist: (productId: string) => void;
     isWishlisted: (productId: string) => boolean;
+    clearWishlist: () => void;
 }
 
 export const useWishlistStore = create<WishlistState>()(
@@ -24,6 +25,7 @@ export const useWishlistStore = create<WishlistState>()(
             isWishlisted: (productId: string) => {
                 return get().wishlistIds.includes(productId);
             },
+            clearWishlist: () => set({ wishlistIds: [] }),
         }),
         {
             name: 'wishlist-storage', // LocalStorage Key


### PR DESCRIPTION
resolved issue: #17 

---

### 1. 기존 헤더 윗쪽에 여백이 있던 디자인을 변경

<img width="1387" height="668" alt="스크린샷 2026-01-24 153506" src="https://github.com/user-attachments/assets/c8fdabbc-a9ba-4567-9b5b-4e80d00792ba" /><br>
<img width="1391" height="863" alt="스크린샷 2026-01-24 153521" src="https://github.com/user-attachments/assets/af9d7b05-ecb8-440e-90ce-92c2ec2b1a98" /><br>

---

### 2. 장바구니에 Zustand 도입, 상세 페이지에 장바구니 추가 버튼 구현

<img width="522" height="415" alt="image" src="https://github.com/user-attachments/assets/0d2b2a04-42cd-4cf4-93f6-f1cd4226040a" /><br>

---

### 3. 로그아웃 시 zustand와 localstorage에 담겨 있는 내용이 초기화되도록 구현(zustand와 localstorage는 동기화되어있음)

<img width="522" height="323" alt="image" src="https://github.com/user-attachments/assets/652ecbd0-2cce-4b2d-a84b-9bfe909f42f8" /><br>
