### PR TITLE
[FEAT] 상품 등록 페이지 구현 (#40)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ function App() {
           <Route path="/mypage/settlement" element={<SettlementList />} />
           <Route path="/mypage/settlement/:settlementId" element={<SettlementDetail />} />
           <Route path="/admin/settlement" element={<AdminSettlement />} />
-          <Route path="/admin/products/management" element={<AdminProductManagement />} />
+          <Route path="/admin/products/manage" element={<AdminProductManagement />} />
           <Route path="/error" element={<ErrorPage />} />
           <Route path="*" element={<ErrorPage />} />
         </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { PaymentSuccessPage } from './pages/PaymentSuccessPage';
 import { PaymentFailPage } from './pages/PaymentFailPage';
 import { CheckoutPage } from './pages/CheckoutPage';
 import { AdminSettlement } from './pages/admin/AdminSettlement';
+import { AdminProductManagement } from "./pages/admin/AdminProductManagement";
 import { SettlementList } from './pages/SettlementList';
 import { SettlementDetail } from './pages/SettlementDetail';
 import { ErrorPage } from './pages/ErrorPage';
@@ -46,6 +47,7 @@ function App() {
           <Route path="/mypage/settlement" element={<SettlementList />} />
           <Route path="/mypage/settlement/:settlementId" element={<SettlementDetail />} />
           <Route path="/admin/settlement" element={<AdminSettlement />} />
+          <Route path="/admin/products/management" element={<AdminProductManagement />} />
           <Route path="/error" element={<ErrorPage />} />
           <Route path="*" element={<ErrorPage />} />
         </Route>

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -4,7 +4,7 @@ import type {
     CategoryResponse,
     PaginatedProductList,
     ProductFilter,
-    ProductDetailResponse
+    ProductDetailResponse, ProductCreateRequest, ProductUpdateRequest, OptionGroupResponse
 } from '../types/product';
 
 // URL 쿼리 파라미터 생성 헬퍼
@@ -72,3 +72,21 @@ export const getCategories = async (): Promise<CategoryResponse[]> => {
     const response = await axiosInstance.get('/api/v1/products/categories');
     return response.data.data.categories;
 };
+
+// 상품 생성
+export const createProduct = async (productData: ProductCreateRequest): Promise<ProductDetailResponse> => {
+    const response = await axiosInstance.post('/api/v1/products', productData);
+    return response.data.data;
+};
+
+// 상품 수정
+export const updateProduct = async (productInfoId: number, productData: ProductUpdateRequest): Promise<ProductDetailResponse> => {
+    const response = await axiosInstance.put(`/api/v1/products/${productInfoId}`, productData);
+    return response.data.data;
+};
+
+// 상품 옵션 목록 조회
+export const getOptions = async (): Promise<OptionGroupResponse[]> => {
+    const response = await axiosInstance.get('/api/v1/products/options')
+    return response.data.data;
+}

--- a/src/components/HeaderV2.tsx
+++ b/src/components/HeaderV2.tsx
@@ -106,12 +106,22 @@ export const HeaderV2 = () => {
     const { isAuthenticated } = useAuthStore();
     const { cartItems, clearCart } = useCartStore();
     const { clearWishlist } = useWishlistStore();
+    const [searchKeyword, setSearchKeyword] = useState('');
+    const navigate = useNavigate();
 
     const handleLogout = async () => {
         await logout();
         clearCart();
         clearWishlist();
         window.location.href = '/';
+    };
+
+    const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (searchKeyword.trim()) {
+            navigate(`/shop?keyword=${searchKeyword}`);
+            setSearchKeyword('');
+        }
     };
 
     useEffect(() => {
@@ -179,14 +189,16 @@ export const HeaderV2 = () => {
                 {/* Right Actions */}
                 <div className="flex items-center gap-2 md:gap-4">
                     {/* Search Bar (Desktop) */}
-                    <div className="hidden md:flex items-center bg-black/5 hover:bg-black/10 rounded-full px-4 py-2 transition-colors cursor-pointer group">
+                    <form onSubmit={handleSearch} className="hidden md:flex items-center bg-black/5 hover:bg-black/10 rounded-full px-4 py-2 transition-colors group">
                         <Search size={18} className="text-gray-500 group-hover:text-black transition-colors" />
                         <input
                             type="text"
                             placeholder="검색어를 입력하세요"
                             className="bg-transparent border-none outline-none ml-2 text-sm w-32 focus:w-48 transition-all duration-300"
+                            value={searchKeyword}
+                            onChange={(e) => setSearchKeyword(e.target.value)}
                         />
-                    </div>
+                    </form>
 
                     <div className="flex items-center gap-1 md:gap-3 relative" ref={notifContainerRef}>
                         {/* Notifications */}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,37 +2,41 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ProductCard } from '../components/ProductCard';
 import { SearchBar } from '../components/SearchBar';
-import { getProducts } from '../api/product';
-import type { ProductListResponse } from '../types/product';
+import { getProducts, getCategories } from '../api/product';
+import type { ProductListResponse, CategoryResponse } from '../types/product';
 import { Loader2, AlertCircle } from 'lucide-react';
-
-const CATEGORIES = ["전체", "스니커즈", "의류", "액세서리", "컬렉터블"];
 
 export const Home = () => {
     const navigate = useNavigate();
     const [products, setProducts] = useState<ProductListResponse[]>([]);
+    const [categories, setCategories] = useState<CategoryResponse[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [activeCategory, setActiveCategory] = useState("전체");
     const [searchKeyword, setSearchKeyword] = useState('');
-    const [totalElements, setTotalElements] = useState(0); // Add totalElements state
+    const [totalElements, setTotalElements] = useState(0);
 
     useEffect(() => {
-        const fetchPopularProducts = async () => {
+        const fetchInitialData = async () => {
             setIsLoading(true);
             setError(null);
             try {
-                const response = await getProducts({ page: 0, size: 8, sort: 'LATEST' });
-                setProducts(response.products); // Extract products from the paginated response
-                setTotalElements(response.totalElements); // Set totalElements
+                const [productResponse, categoryResponse] = await Promise.all([
+                    getProducts({ page: 0, size: 8, sort: 'LATEST' }),
+                    getCategories()
+                ]);
+                setProducts(productResponse.products);
+                setTotalElements(productResponse.totalElements);
+                // "전체" 카테고리를 맨 앞에 추가
+                setCategories([{ categoryId: 0, name: "전체" }, ...categoryResponse]);
             } catch (err) {
-                setError('인기 상품을 불러오는 데 실패했습니다.');
+                setError('데이터를 불러오는 데 실패했습니다.');
                 console.error(err);
             } finally {
                 setIsLoading(false);
             }
         };
-        fetchPopularProducts();
+        fetchInitialData();
     }, []);
 
     const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
@@ -72,17 +76,17 @@ export const Home = () => {
 
             <div className="sticky top-[60px] z-[50] border-b border-[#eee] bg-white py-4">
                 <ul className="flex justify-center gap-4 m-0 p-0 list-none">
-                    {CATEGORIES.map(cat => (
-                        <li key={cat}>
+                    {categories.map(cat => (
+                        <li key={cat.categoryId}>
                             <button
                                 className={`rounded-[20px] border border-solid px-5 py-2 text-sm transition-all duration-200 cursor-pointer
-                                    ${activeCategory === cat
+                                    ${activeCategory === cat.name
                                         ? 'bg-white border-[#5c6bc0]/40 text-[#333] font-bold shadow-[0_2px_8px_rgba(92,107,192,0.2)] -translate-y-[0.5px]'
                                         : 'bg-white border-gray-200 text-[#888] hover:border-gray-300 hover:text-[#333]'
                                     }`}
-                                onClick={() => handleCategoryClick(cat)}
+                                onClick={() => handleCategoryClick(cat.name)}
                             >
-                                {cat}
+                                {cat.name}
                             </button>
                         </li>
                     ))}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -46,9 +46,11 @@ export const Home = () => {
         }
     };
 
-    const handleCategoryClick = (category: string) => {
-        setActiveCategory(category);
-        navigate(`/shop?categoryName=${category === '전체' ? '' : category}`);
+    const handleCategoryClick = (category: CategoryResponse) => {
+        setActiveCategory(category.name);
+        // "전체" 카테고리인 경우 categoryId를 전달하지 않아 Shop 페이지에서 모든 카테고리를 조회하도록 합니다.
+        const categoryParam = category.name === '전체' ? '' : `category=${category.categoryId}`;
+        navigate(`/shop?${categoryParam}`);
     }
 
     return (
@@ -84,7 +86,7 @@ export const Home = () => {
                                         ? 'bg-white border-[#5c6bc0]/40 text-[#333] font-bold shadow-[0_2px_8px_rgba(92,107,192,0.2)] -translate-y-[0.5px]'
                                         : 'bg-white border-gray-200 text-[#888] hover:border-gray-300 hover:text-[#333]'
                                     }`}
-                                onClick={() => handleCategoryClick(cat.name)}
+                                onClick={() => handleCategoryClick(cat)}
                             >
                                 {cat.name}
                             </button>

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -74,19 +74,20 @@ export const Shop = () => {
     useEffect(() => {
         const filters = {
             page,
+            keyword: searchKeyword,
             brandId: activeBrandId,
             categoryId: activeCategoryId
         };
-        // Trigger fetch only for page, brand, and category changes
+        // Trigger fetch for page, brand, category, and keyword changes
         fetchProducts(filters);
 
         const newSearchParams = new URLSearchParams();
         if (searchKeyword) newSearchParams.set('keyword', searchKeyword);
         if (activeBrandId) newSearchParams.set('brand', String(activeBrandId));
         if (activeCategoryId) newSearchParams.set('category', String(activeCategoryId));
-        setSearchParams(newSearchParams);
+        setSearchParams(newSearchParams, { replace: true });
 
-    }, [page, activeBrandId, activeCategoryId, fetchProducts, setSearchParams]);
+    }, [page, searchKeyword, activeBrandId, activeCategoryId, fetchProducts, setSearchParams]);
 
     useEffect(() => {
         const fetchFilters = async () => {
@@ -154,7 +155,7 @@ export const Shop = () => {
                                         }`}
                                     onClick={() => { setActiveBrandId(null); setPage(0); }}
                                 >
-                                    전체 브랜드
+                                    전체
                                 </button>
                             </li>
                             {brands.map(brand => (

--- a/src/pages/admin/AdminProductManagement.tsx
+++ b/src/pages/admin/AdminProductManagement.tsx
@@ -1,0 +1,317 @@
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+    ChevronLeft, Plus, Trash2, Image as ImageIcon, X, Loader2, Info, ArrowDown, ArrowUp, Check
+} from 'lucide-react';
+
+// --- Mock API Service & Data ---
+// In a real application, move to src/api/ and src/types/
+const mockApi = {
+    getBrands: async () => [
+        { brandId: 1, name: 'Nike', logoUrl: '...' },
+        { brandId: 2, name: 'Adidas', logoUrl: '...' }
+    ],
+    getCategories: async () => [
+        { categoryId: 1, name: '신발', imageUrl: '...' },
+        { categoryId: 2, name: '의류', imageUrl: '...' }
+    ],
+    getOptionValues: async () => [
+        { id: 1, value: '250', groupName: '사이즈' },
+        { id: 2, value: '260', groupName: '사이즈' },
+        { id: 3, value: '270', groupName: '사이즈' },
+        { id: 4, value: 'Black', groupName: '색상' },
+        { id: 5, value: 'White', groupName: '색상' },
+    ],
+    getProduct: async (id: number) => ({
+        productInfo: { brandId: 1, categoryId: 1, name: 'Air Force 1', code: 'AF1-001', releasePrice: 139000, releasedDate: new Date().toISOString().substring(0, 16) },
+        variants: [{ productId: 101, optionValueIds: [3, 5], inventory: 10, imageUrls: ['https://example.com/image1.jpg'] }],
+    }),
+    createProduct: async (data: any) => ({ id: 100, ...data }),
+    updateProduct: async (id: number, data: any) => ({ id, ...data }),
+};
+
+interface Brand { brandId: number; name: string; }
+interface Category { categoryId: number; name:string; }
+interface OptionValue { id: number; value: string; groupName: string; }
+interface ProductInfoData { brandId: number | ''; categoryId: number | ''; name: string; code: string; releasePrice: number; releasedDate: string; }
+interface ProductVariantData { productId?: number; optionValueIds: number[]; inventory: number; imageUrls: string[]; }
+interface ProductFormData { productInfo: ProductInfoData; variants: ProductVariantData[]; }
+
+// Reusable Components matching project style
+const FormCard: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+    <div className="bg-white rounded-2xl p-8 border border-gray-100 shadow-sm">
+        <h3 className="text-xl font-bold text-[#333] mb-8 pb-4 border-b border-gray-100">{title}</h3>
+        {children}
+    </div>
+);
+
+const FormField: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+    <div>
+        <label className="text-sm font-bold text-gray-500 mb-2 block">{label}</label>
+        {children}
+    </div>
+);
+
+const StyledInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition" />
+);
+
+const StyledSelect = (props: React.SelectHTMLAttributes<HTMLSelectElement>) => (
+    <select {...props} className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition appearance-none bg-no-repeat bg-right" style={{ backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e")`, backgroundPosition: 'right 0.7rem center', backgroundSize: '1.2em 1.2em' }} />
+);
+
+const PrimaryButton: React.FC<{ children: React.ReactNode, onClick?: () => void, type?: 'button'|'submit', disabled?: boolean }> =
+    ({ children, ...props }) => (
+    <button {...props} className="h-14 w-full bg-gray-900 text-white font-bold rounded-xl shadow-md shadow-gray-900/10 transition-all hover:bg-gray-800 active:scale-[0.98] disabled:bg-gray-300 disabled:shadow-none">
+        {children}
+    </button>
+);
+
+// New Admin Product Management Page
+export const AdminProductManagement = () => {
+    const { productInfoId } = useParams<{ productInfoId: string }>();
+    const navigate = useNavigate();
+    const isEditing = Boolean(productInfoId);
+
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    
+    const [formData, setFormData] = useState<ProductFormData>({
+        productInfo: { brandId: '', categoryId: '', name: '', code: '', releasePrice: 0, releasedDate: '' },
+        variants: [],
+    });
+
+    const [brands, setBrands] = useState<Brand[]>([]);
+    const [categories, setCategories] = useState<Category[]>([]);
+    const [optionValues, setOptionValues] = useState<OptionValue[]>([]);
+
+    // Data Fetching
+    useEffect(() => {
+        const fetchData = async () => {
+            setIsLoading(true);
+            try {
+                const [brandsData, categoriesData, optionValuesData] = await Promise.all([
+                    mockApi.getBrands(), mockApi.getCategories(), mockApi.getOptionValues(),
+                ]);
+                setBrands(brandsData);
+                setCategories(categoriesData);
+                setOptionValues(optionValuesData);
+
+                if (isEditing && productInfoId) {
+                    const productData = await mockApi.getProduct(Number(productInfoId));
+                    setFormData(productData);
+                }
+            } catch (err) {
+                console.error("Failed to load initial data", err);
+                alert("데이터 로딩에 실패했습니다.");
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchData();
+    }, [isEditing, productInfoId]);
+
+    // Handlers
+    const handleInfoChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({
+            ...prev,
+            productInfo: {
+                ...prev.productInfo,
+                [name]: (name === 'brandId' || name === 'categoryId' || name === 'releasePrice') && value ? Number(value) : value,
+            },
+        }));
+    };
+
+    const handleVariantChange = (index: number, field: keyof ProductVariantData, value: any) => {
+        const newVariants = [...formData.variants];
+        (newVariants[index] as any)[field] = value;
+        setFormData(prev => ({ ...prev, variants: newVariants }));
+    };
+
+    const addVariant = () => {
+        setFormData(prev => ({
+            ...prev,
+            variants: [...prev.variants, { optionValueIds: [], inventory: 0, imageUrls: [''] }],
+        }));
+    };
+
+    const removeVariant = (index: number) => {
+        setFormData(prev => ({
+            ...prev, variants: prev.variants.filter((_, i) => i !== index),
+        }));
+    };
+
+    const handleImageUrlChange = (variantIndex: number, imageIndex: number, value: string) => {
+        const newVariants = [...formData.variants];
+        newVariants[variantIndex].imageUrls[imageIndex] = value;
+        setFormData(prev => ({ ...prev, variants: newVariants }));
+    };
+
+    const addImageUrl = (variantIndex: number) => {
+        const newVariants = [...formData.variants];
+        newVariants[variantIndex].imageUrls.push('');
+        setFormData(prev => ({ ...prev, variants: newVariants }));
+    };
+
+    const removeImageUrl = (variantIndex: number, imageIndex: number) => {
+        setFormData(prev => ({
+            ...prev,
+            variants: prev.variants.map((variant, vIdx) => vIdx === variantIndex
+                ? { ...variant, imageUrls: variant.imageUrls.filter((_, iIdx) => iIdx !== imageIndex) }
+                : variant
+            ),
+        }));
+    };
+    
+    const toggleOptionValue = (variantIndex: number, optionValueId: number) => {
+        const newVariants = [...formData.variants];
+        const currentOptions = newVariants[variantIndex].optionValueIds;
+        if (currentOptions.includes(optionValueId)) {
+            newVariants[variantIndex].optionValueIds = currentOptions.filter(id => id !== optionValueId);
+        } else {
+            newVariants[variantIndex].optionValueIds.push(optionValueId);
+        }
+        setFormData(prev => ({ ...prev, variants: newVariants }));
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setIsSubmitting(true);
+        try {
+            if (isEditing && productInfoId) {
+                await mockApi.updateProduct(Number(productInfoId), formData);
+                alert('상품이 수정되었습니다.');
+            } else {
+                await mockApi.createProduct(formData);
+                alert('상품이 등록되었습니다.');
+            }
+            navigate('/admin'); // Redirect to some admin list page
+        } catch (error) {
+            console.error('Failed to save product:', error);
+            alert('상품 저장에 실패했습니다.');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const groupedOptions = useMemo(() => {
+        return optionValues.reduce((acc, option) => {
+            (acc[option.groupName] = acc[option.groupName] || []).push(option);
+            return acc;
+        }, {} as Record<string, OptionValue[]>);
+    }, [optionValues]);
+
+    if (isLoading) {
+        return <div className="flex justify-center items-center h-screen"><Loader2 className="animate-spin w-10 h-10" /></div>;
+    }
+
+    return (
+        <div className="min-h-screen bg-gray-50 pt-[100px] pb-24 px-6 font-pretendard">
+            <div className="max-w-5xl mx-auto">
+                <div className="flex items-center gap-4 mb-10">
+                    <button onClick={() => navigate(-1)} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+                        <ChevronLeft size={24} className="text-gray-600" />
+                    </button>
+                    <h2 className="text-3xl font-black text-[#333] tracking-tight">{isEditing ? '상품 수정' : '상품 등록'}</h2>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-8">
+                    <FormCard title="상품 기본 정보">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-8">
+                            <FormField label="상품명"><StyledInput name="name" value={formData.productInfo.name} onChange={handleInfoChange} required /></FormField>
+                            <FormField label="상품 코드"><StyledInput name="code" value={formData.productInfo.code} onChange={handleInfoChange} required /></FormField>
+                            <FormField label="브랜드">
+                                <StyledSelect name="brandId" value={formData.productInfo.brandId} onChange={handleInfoChange} required>
+                                    <option value="" disabled>브랜드를 선택하세요</option>
+                                    {brands.map(b => <option key={b.brandId} value={b.brandId}>{b.name}</option>)}
+                                </StyledSelect>
+                            </FormField>
+                            <FormField label="카테고리">
+                                <StyledSelect name="categoryId" value={formData.productInfo.categoryId} onChange={handleInfoChange} required>
+                                    <option value="" disabled>카테고리를 선택하세요</option>
+                                    {categories.map(c => <option key={c.categoryId} value={c.categoryId}>{c.name}</option>)}
+                                </StyledSelect>
+                            </FormField>
+                            <FormField label="발매가"><StyledInput type="number" name="releasePrice" value={formData.productInfo.releasePrice} onChange={handleInfoChange} required /></FormField>
+                            <FormField label="발매일"><StyledInput type="datetime-local" name="releasedDate" value={formData.productInfo.releasedDate} onChange={handleInfoChange} required /></FormField>
+                        </div>
+                    </FormCard>
+
+                    <FormCard title="상품 옵션 (Variants)">
+                        <div className="space-y-6">
+                            {formData.variants.map((variant, vIdx) => (
+                                <div key={vIdx} className="bg-gray-50/70 p-6 rounded-xl border border-gray-200/80 relative">
+                                    <h4 className="font-bold text-gray-700 mb-4">옵션 #{vIdx + 1}</h4>
+                                    
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6">
+                                        <FormField label="재고">
+                                            <StyledInput type="number" value={variant.inventory} onChange={e => handleVariantChange(vIdx, 'inventory', Number(e.target.value))} />
+                                        </FormField>
+                                        
+                                        <FormField label="옵션 선택">
+                                            <div className="space-y-4">
+                                                {Object.entries(groupedOptions).map(([groupName, options]) => (
+                                                    <div key={groupName}>
+                                                        <p className="text-xs font-semibold text-gray-600 mb-2">{groupName}</p>
+                                                        <div className="flex flex-wrap gap-2">
+                                                            {options.map(opt => (
+                                                                <button key={opt.id} type="button" onClick={() => toggleOptionValue(vIdx, opt.id)} className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${variant.optionValueIds.includes(opt.id) ? 'bg-accent/10 border-accent text-accent' : 'bg-white border-gray-200 hover:border-gray-400'}`}>
+                                                                    {opt.value}
+                                                                </button>
+                                                            ))}
+                                                        </div>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        </FormField>
+                                        
+                                        <div className="md:col-span-2">
+                                        <FormField label="이미지 URL">
+                                            <div className="space-y-3">
+                                            {variant.imageUrls.map((url, iIdx) => (
+                                                <div key={iIdx} className="flex items-center gap-2">
+                                                    <StyledInput type="url" placeholder="https://example.com/image.jpg" value={url} onChange={e => handleImageUrlChange(vIdx, iIdx, e.target.value)} required />
+                                                    <button type="button" onClick={() => removeImageUrl(vIdx, iIdx)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
+                                                        <Trash2 size={16} />
+                                                    </button>
+                                                </div>
+                                            ))}
+                                            <button type="button" onClick={() => addImageUrl(vIdx)} className="w-full mt-2 flex items-center justify-center gap-2 text-sm font-medium text-gray-500 bg-white border-2 border-dashed border-gray-300 rounded-lg py-3 hover:bg-gray-50 hover:border-gray-400 transition-colors">
+                                                <ImageIcon size={16} /> 이미지 URL 추가
+                                            </button>
+                                            </div>
+                                        </FormField>
+                                        </div>
+                                    </div>
+                                    
+                                    <button type="button" onClick={() => removeVariant(vIdx)} className="absolute top-4 right-4 p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
+                                        <X size={18} />
+                                    </button>
+                                </div>
+                            ))}
+                             <button type="button" onClick={addVariant} className="w-full flex items-center justify-center gap-2 text-sm font-bold text-accent bg-accent/5 border-2 border-dashed border-accent/20 rounded-xl py-4 hover:bg-accent/10 transition-colors">
+                                <Plus size={16} /> 새 옵션 추가
+                            </button>
+                        </div>
+                    </FormCard>
+
+                    <div className="flex justify-end pt-4">
+                        <div className="w-full md:w-1/4">
+                        <PrimaryButton type="submit" disabled={isSubmitting}>
+                            {isSubmitting
+                                ? <Loader2 className="animate-spin mx-auto"/>
+                                : isEditing ? '상품 수정하기' : '상품 등록하기'
+                            }
+                        </PrimaryButton>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default AdminProductManagement;
+

--- a/src/pages/admin/AdminProductManagement.tsx
+++ b/src/pages/admin/AdminProductManagement.tsx
@@ -1,42 +1,45 @@
-
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
-    ChevronLeft, Plus, Trash2, Image as ImageIcon, X, Loader2, Info, ArrowDown, ArrowUp, Check
+    getBrands,
+    getCategories,
+    getOptions,
+    getProductDetail,
+    createProduct,
+    updateProduct,
+} from '../../api/product';
+import type {
+    BrandResponse as Brand,
+    CategoryResponse as Category,
+    OptionGroupResponse,
+    ProductCreateRequest,
+    ProductUpdateRequest,
+} from '../../types/product';
+import {
+    ChevronLeft, Plus, Trash2, Image as ImageIcon, X, Loader2
 } from 'lucide-react';
 
-// --- Mock API Service & Data ---
-// In a real application, move to src/api/ and src/types/
-const mockApi = {
-    getBrands: async () => [
-        { brandId: 1, name: 'Nike', logoUrl: '...' },
-        { brandId: 2, name: 'Adidas', logoUrl: '...' }
-    ],
-    getCategories: async () => [
-        { categoryId: 1, name: '신발', imageUrl: '...' },
-        { categoryId: 2, name: '의류', imageUrl: '...' }
-    ],
-    getOptionValues: async () => [
-        { id: 1, value: '250', groupName: '사이즈' },
-        { id: 2, value: '260', groupName: '사이즈' },
-        { id: 3, value: '270', groupName: '사이즈' },
-        { id: 4, value: 'Black', groupName: '색상' },
-        { id: 5, value: 'White', groupName: '색상' },
-    ],
-    getProduct: async (id: number) => ({
-        productInfo: { brandId: 1, categoryId: 1, name: 'Air Force 1', code: 'AF1-001', releasePrice: 139000, releasedDate: new Date().toISOString().substring(0, 16) },
-        variants: [{ productId: 101, optionValueIds: [3, 5], inventory: 10, imageUrls: ['https://example.com/image1.jpg'] }],
-    }),
-    createProduct: async (data: any) => ({ id: 100, ...data }),
-    updateProduct: async (id: number, data: any) => ({ id, ...data }),
-};
+// Form State에 맞는 로컬 타입 정의
+interface FormProductInfo {
+    brandId: number | '';
+    categoryId: number | '';
+    name: string;
+    code: string;
+    releasePrice: number;
+    releasedDate: string;
+}
 
-interface Brand { brandId: number; name: string; }
-interface Category { categoryId: number; name:string; }
-interface OptionValue { id: number; value: string; groupName: string; }
-interface ProductInfoData { brandId: number | ''; categoryId: number | ''; name: string; code: string; releasePrice: number; releasedDate: string; }
-interface ProductVariantData { productId?: number; optionValueIds: number[]; inventory: number; imageUrls: string[]; }
-interface ProductFormData { productInfo: ProductInfoData; variants: ProductVariantData[]; }
+interface FormVariantData {
+    productId?: number;
+    optionValueIds: number[];
+    inventory: number;
+    imageUrls: string[];
+}
+
+interface FormState {
+    productInfo: FormProductInfo;
+    variants: FormVariantData[];
+}
 
 // Reusable Components matching project style
 const FormCard: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
@@ -54,21 +57,33 @@ const FormField: React.FC<{ label: string; children: React.ReactNode }> = ({ lab
 );
 
 const StyledInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
-    <input {...props} className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition" />
+    <input
+        {...props}
+        className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition"
+    />
 );
 
 const StyledSelect = (props: React.SelectHTMLAttributes<HTMLSelectElement>) => (
-    <select {...props} className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition appearance-none bg-no-repeat bg-right" style={{ backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e")`, backgroundPosition: 'right 0.7rem center', backgroundSize: '1.2em 1.2em' }} />
+    <select
+        {...props}
+        className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition appearance-none bg-no-repeat bg-right"
+        style={{
+            backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e")`,
+            backgroundPosition: 'right 0.7rem center',
+            backgroundSize: '1.2em 1.2em'
+        }}
+    />
 );
 
-const PrimaryButton: React.FC<{ children: React.ReactNode, onClick?: () => void, type?: 'button'|'submit', disabled?: boolean }> =
-    ({ children, ...props }) => (
-    <button {...props} className="h-14 w-full bg-gray-900 text-white font-bold rounded-xl shadow-md shadow-gray-900/10 transition-all hover:bg-gray-800 active:scale-[0.98] disabled:bg-gray-300 disabled:shadow-none">
+const PrimaryButton: React.FC<{ children: React.ReactNode, onClick?: () => void, type?: 'button'|'submit', disabled?: boolean }> = ({ children, ...props }) => (
+    <button
+        {...props}
+        className="h-14 w-full bg-gray-900 text-white font-bold rounded-xl shadow-md shadow-gray-900/10 transition-all hover:bg-gray-800 active:scale-[0.98] disabled:bg-gray-300 disabled:shadow-none"
+    >
         {children}
     </button>
 );
 
-// New Admin Product Management Page
 export const AdminProductManagement = () => {
     const { productInfoId } = useParams<{ productInfoId: string }>();
     const navigate = useNavigate();
@@ -76,31 +91,62 @@ export const AdminProductManagement = () => {
 
     const [isLoading, setIsLoading] = useState(true);
     const [isSubmitting, setIsSubmitting] = useState(false);
-    
-    const [formData, setFormData] = useState<ProductFormData>({
+
+    const [formData, setFormData] = useState<FormState>({
         productInfo: { brandId: '', categoryId: '', name: '', code: '', releasePrice: 0, releasedDate: '' },
         variants: [],
     });
 
     const [brands, setBrands] = useState<Brand[]>([]);
     const [categories, setCategories] = useState<Category[]>([]);
-    const [optionValues, setOptionValues] = useState<OptionValue[]>([]);
+    const [groupedOptions, setGroupedOptions] = useState<OptionGroupResponse[]>([]);
 
-    // Data Fetching
     useEffect(() => {
         const fetchData = async () => {
             setIsLoading(true);
             try {
-                const [brandsData, categoriesData, optionValuesData] = await Promise.all([
-                    mockApi.getBrands(), mockApi.getCategories(), mockApi.getOptionValues(),
+                const [brandsData, categoriesData, optionsData] = await Promise.all([
+                    getBrands(), getCategories(), getOptions(),
                 ]);
                 setBrands(brandsData);
                 setCategories(categoriesData);
-                setOptionValues(optionValuesData);
+                setGroupedOptions(optionsData);
 
                 if (isEditing && productInfoId) {
-                    const productData = await mockApi.getProduct(Number(productInfoId));
-                    setFormData(productData);
+                    const productData = await getProductDetail(Number(productInfoId));
+
+                    const optionValueMap = new Map<string, number>();
+                    optionsData.forEach(group => {
+                        group.optionValues.forEach(val => {
+                            optionValueMap.set(`${group.name}:${val.value}`, val.id);
+                        });
+                    });
+
+                    const mappedVariants = productData.products.map(p => {
+                        const ids = p.options.map(opt => {
+                            const key = `${opt.groupName}:${opt.value}`;
+                            return optionValueMap.get(key);
+                        }).filter((id): id is number => id !== undefined);
+
+                        return {
+                            productId: p.productId,
+                            inventory: p.inventory,
+                            optionValueIds: ids,
+                            imageUrls: p.imageUrls,
+                        };
+                    });
+
+                    setFormData({
+                        productInfo: {
+                            brandId: productData.productInfo.brand.brandId,
+                            categoryId: productData.productInfo.category.categoryId,
+                            name: productData.productInfo.name,
+                            code: productData.productInfo.code,
+                            releasePrice: productData.productInfo.releasePrice,
+                            releasedDate: new Date(productData.productInfo.releaseDate).toISOString().substring(0, 16),
+                        },
+                        variants: mappedVariants
+                    });
                 }
             } catch (err) {
                 console.error("Failed to load initial data", err);
@@ -112,7 +158,6 @@ export const AdminProductManagement = () => {
         fetchData();
     }, [isEditing, productInfoId]);
 
-    // Handlers
     const handleInfoChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
         const { name, value } = e.target;
         setFormData(prev => ({
@@ -124,7 +169,7 @@ export const AdminProductManagement = () => {
         }));
     };
 
-    const handleVariantChange = (index: number, field: keyof ProductVariantData, value: any) => {
+    const handleVariantChange = (index: number, field: keyof FormVariantData, value: any) => {
         const newVariants = [...formData.variants];
         (newVariants[index] as any)[field] = value;
         setFormData(prev => ({ ...prev, variants: newVariants }));
@@ -139,7 +184,8 @@ export const AdminProductManagement = () => {
 
     const removeVariant = (index: number) => {
         setFormData(prev => ({
-            ...prev, variants: prev.variants.filter((_, i) => i !== index),
+            ...prev,
+            variants: prev.variants.filter((_, i) => i !== index),
         }));
     };
 
@@ -164,7 +210,7 @@ export const AdminProductManagement = () => {
             ),
         }));
     };
-    
+
     const toggleOptionValue = (variantIndex: number, optionValueId: number) => {
         const newVariants = [...formData.variants];
         const currentOptions = newVariants[variantIndex].optionValueIds;
@@ -178,16 +224,33 @@ export const AdminProductManagement = () => {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+
+        if (!formData.productInfo.brandId || !formData.productInfo.categoryId) {
+            alert("브랜드와 카테고리를 선택해주세요.");
+            return;
+        }
+
         setIsSubmitting(true);
         try {
+            const payload: ProductCreateRequest | ProductUpdateRequest = {
+                ...formData,
+                productInfo: {
+                    ...formData.productInfo,
+                    brandId: Number(formData.productInfo.brandId),
+                    categoryId: Number(formData.productInfo.categoryId),
+                    releasedDate: new Date(formData.productInfo.releasedDate).toISOString()
+                },
+                variants: formData.variants,
+            };
+
             if (isEditing && productInfoId) {
-                await mockApi.updateProduct(Number(productInfoId), formData);
+                await updateProduct(Number(productInfoId), payload as ProductUpdateRequest);
                 alert('상품이 수정되었습니다.');
             } else {
-                await mockApi.createProduct(formData);
+                await createProduct(payload as ProductCreateRequest);
                 alert('상품이 등록되었습니다.');
             }
-            navigate('/admin'); // Redirect to some admin list page
+            navigate('/'); // 임시로, 메인 페이지로 이동
         } catch (error) {
             console.error('Failed to save product:', error);
             alert('상품 저장에 실패했습니다.');
@@ -195,13 +258,6 @@ export const AdminProductManagement = () => {
             setIsSubmitting(false);
         }
     };
-
-    const groupedOptions = useMemo(() => {
-        return optionValues.reduce((acc, option) => {
-            (acc[option.groupName] = acc[option.groupName] || []).push(option);
-            return acc;
-        }, {} as Record<string, OptionValue[]>);
-    }, [optionValues]);
 
     if (isLoading) {
         return <div className="flex justify-center items-center h-screen"><Loader2 className="animate-spin w-10 h-10" /></div>;
@@ -220,8 +276,12 @@ export const AdminProductManagement = () => {
                 <form onSubmit={handleSubmit} className="space-y-8">
                     <FormCard title="상품 기본 정보">
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-8">
-                            <FormField label="상품명"><StyledInput name="name" value={formData.productInfo.name} onChange={handleInfoChange} required /></FormField>
-                            <FormField label="상품 코드"><StyledInput name="code" value={formData.productInfo.code} onChange={handleInfoChange} required /></FormField>
+                            <FormField label="상품명">
+                                <StyledInput name="name" value={formData.productInfo.name} onChange={handleInfoChange} required />
+                            </FormField>
+                            <FormField label="상품 코드">
+                                <StyledInput name="code" value={formData.productInfo.code} onChange={handleInfoChange} required />
+                            </FormField>
                             <FormField label="브랜드">
                                 <StyledSelect name="brandId" value={formData.productInfo.brandId} onChange={handleInfoChange} required>
                                     <option value="" disabled>브랜드를 선택하세요</option>
@@ -234,8 +294,12 @@ export const AdminProductManagement = () => {
                                     {categories.map(c => <option key={c.categoryId} value={c.categoryId}>{c.name}</option>)}
                                 </StyledSelect>
                             </FormField>
-                            <FormField label="발매가"><StyledInput type="number" name="releasePrice" value={formData.productInfo.releasePrice} onChange={handleInfoChange} required /></FormField>
-                            <FormField label="발매일"><StyledInput type="datetime-local" name="releasedDate" value={formData.productInfo.releasedDate} onChange={handleInfoChange} required /></FormField>
+                            <FormField label="발매가">
+                                <StyledInput type="number" name="releasePrice" value={formData.productInfo.releasePrice} onChange={handleInfoChange} required />
+                            </FormField>
+                            <FormField label="발매일">
+                                <StyledInput type="datetime-local" name="releasedDate" value={formData.productInfo.releasedDate} onChange={handleInfoChange} required />
+                            </FormField>
                         </div>
                     </FormCard>
 
@@ -244,20 +308,23 @@ export const AdminProductManagement = () => {
                             {formData.variants.map((variant, vIdx) => (
                                 <div key={vIdx} className="bg-gray-50/70 p-6 rounded-xl border border-gray-200/80 relative">
                                     <h4 className="font-bold text-gray-700 mb-4">옵션 #{vIdx + 1}</h4>
-                                    
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6">
                                         <FormField label="재고">
                                             <StyledInput type="number" value={variant.inventory} onChange={e => handleVariantChange(vIdx, 'inventory', Number(e.target.value))} />
                                         </FormField>
-                                        
                                         <FormField label="옵션 선택">
                                             <div className="space-y-4">
-                                                {Object.entries(groupedOptions).map(([groupName, options]) => (
-                                                    <div key={groupName}>
-                                                        <p className="text-xs font-semibold text-gray-600 mb-2">{groupName}</p>
+                                                {groupedOptions.map((group) => (
+                                                    <div key={group.id}>
+                                                        <p className="text-xs font-semibold text-gray-600 mb-2">{group.name}</p>
                                                         <div className="flex flex-wrap gap-2">
-                                                            {options.map(opt => (
-                                                                <button key={opt.id} type="button" onClick={() => toggleOptionValue(vIdx, opt.id)} className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${variant.optionValueIds.includes(opt.id) ? 'bg-accent/10 border-accent text-accent' : 'bg-white border-gray-200 hover:border-gray-400'}`}>
+                                                            {group.optionValues.map(opt => (
+                                                                <button
+                                                                    key={opt.id}
+                                                                    type="button"
+                                                                    onClick={() => toggleOptionValue(vIdx, opt.id)}
+                                                                    className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${variant.optionValueIds.includes(opt.id) ? 'bg-accent/10 border-accent text-accent' : 'bg-white border-gray-200 hover:border-gray-400'}`}
+                                                                >
                                                                     {opt.value}
                                                                 </button>
                                                             ))}
@@ -266,32 +333,38 @@ export const AdminProductManagement = () => {
                                                 ))}
                                             </div>
                                         </FormField>
-                                        
                                         <div className="md:col-span-2">
-                                        <FormField label="이미지 URL">
-                                            <div className="space-y-3">
-                                            {variant.imageUrls.map((url, iIdx) => (
-                                                <div key={iIdx} className="flex items-center gap-2">
-                                                    <StyledInput type="url" placeholder="https://example.com/image.jpg" value={url} onChange={e => handleImageUrlChange(vIdx, iIdx, e.target.value)} required />
-                                                    <button type="button" onClick={() => removeImageUrl(vIdx, iIdx)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
-                                                        <Trash2 size={16} />
+                                            <FormField label="이미지 URL">
+                                                <div className="space-y-3">
+                                                    {variant.imageUrls.map((url, iIdx) => (
+                                                        <div key={iIdx} className="flex items-center gap-2">
+                                                            <StyledInput type="url" placeholder="https://example.com/image.jpg" value={url} onChange={e => handleImageUrlChange(vIdx, iIdx, e.target.value)} required />
+                                                            <button type="button" onClick={() => removeImageUrl(vIdx, iIdx)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
+                                                                <Trash2 size={16} />
+                                                            </button>
+                                                        </div>
+                                                    ))}
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => addImageUrl(vIdx)}
+                                                        className="w-full mt-2 flex items-center justify-center gap-2 text-sm font-medium text-gray-500 bg-white border-2 border-dashed border-gray-300 rounded-lg py-3 hover:bg-gray-50 hover:border-gray-400 transition-colors"
+                                                    >
+                                                        <ImageIcon size={16} /> 이미지 URL 추가
                                                     </button>
                                                 </div>
-                                            ))}
-                                            <button type="button" onClick={() => addImageUrl(vIdx)} className="w-full mt-2 flex items-center justify-center gap-2 text-sm font-medium text-gray-500 bg-white border-2 border-dashed border-gray-300 rounded-lg py-3 hover:bg-gray-50 hover:border-gray-400 transition-colors">
-                                                <ImageIcon size={16} /> 이미지 URL 추가
-                                            </button>
-                                            </div>
-                                        </FormField>
+                                            </FormField>
                                         </div>
                                     </div>
-                                    
                                     <button type="button" onClick={() => removeVariant(vIdx)} className="absolute top-4 right-4 p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
                                         <X size={18} />
                                     </button>
                                 </div>
                             ))}
-                             <button type="button" onClick={addVariant} className="w-full flex items-center justify-center gap-2 text-sm font-bold text-accent bg-accent/5 border-2 border-dashed border-accent/20 rounded-xl py-4 hover:bg-accent/10 transition-colors">
+                            <button
+                                type="button"
+                                onClick={addVariant}
+                                className="w-full flex items-center justify-center gap-2 text-sm font-bold text-accent bg-accent/5 border-2 border-dashed border-accent/20 rounded-xl py-4 hover:bg-accent/10 transition-colors"
+                            >
                                 <Plus size={16} /> 새 옵션 추가
                             </button>
                         </div>
@@ -299,12 +372,9 @@ export const AdminProductManagement = () => {
 
                     <div className="flex justify-end pt-4">
                         <div className="w-full md:w-1/4">
-                        <PrimaryButton type="submit" disabled={isSubmitting}>
-                            {isSubmitting
-                                ? <Loader2 className="animate-spin mx-auto"/>
-                                : isEditing ? '상품 수정하기' : '상품 등록하기'
-                            }
-                        </PrimaryButton>
+                            <PrimaryButton type="submit" disabled={isSubmitting}>
+                                {isSubmitting ? <Loader2 className="animate-spin mx-auto"/> : isEditing ? '상품 수정하기' : '상품 등록하기'}
+                            </PrimaryButton>
                         </div>
                     </div>
                 </form>
@@ -314,4 +384,3 @@ export const AdminProductManagement = () => {
 };
 
 export default AdminProductManagement;
-

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,3 +1,14 @@
+export interface OptionGroupResponse {
+    id: number;
+    name: string;
+    optionValues: OptionValue[];
+}
+
+export interface OptionValue {
+    id: number;
+    value: string;
+}
+
 // 상품 개별 옵션 정보
 export interface ProductOption {
     productOptionValueId: number;
@@ -82,4 +93,47 @@ export interface ProductFilter {
     categoryIds?: number[];
     excludeSoldOut?: boolean;
     sort?: string; // 예: 'LATEST', 'PRICE_LOW'
+}
+
+// --- 상품 생성 및 수정 요청 타입 ---
+
+export interface ProductInfoCreateRequest {
+    brandId: number;
+    categoryId: number;
+    name: string;
+    code: string;
+    releasePrice: number;
+    releasedDate: string; // ISO 8601 format
+}
+
+export interface ProductVariantCreateRequest {
+    optionValueIds: number[];
+    inventory: number;
+    imageUrls: string[];
+}
+
+export interface ProductCreateRequest {
+    productInfo: ProductInfoCreateRequest;
+    variants: ProductVariantCreateRequest[];
+}
+
+export interface ProductInfoUpdateRequest {
+    brandId: number;
+    categoryId: number;
+    name: string;
+    code: string;
+    releasePrice: number;
+    releasedDate: string;
+}
+
+export interface ProductVariantUpdateRequest {
+    productId?: number; // 기존 variant를 수정할 때 필요
+    optionValueIds: number[];
+    inventory: number;
+    imageUrls: string[];
+}
+
+export interface ProductUpdateRequest {
+    productInfo: ProductInfoUpdateRequest;
+    variants: ProductVariantUpdateRequest[];
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #40

## 🔎 작업 내용

- 관리자 상품 등록 및 수정 페이지 기능 개발
- 헤더에 검색 기능 추가 및 홈페이지 검색 기능 개선
- 카테고리 클릭 시, 해당 카테고리 상품 목록 조회 페이지로 이동 기능 구현
- 카테고리 조회 API 호출 로직 수정
- 경로 이름 수정

## 📷 테스트 결과
- 상품 등록 페이지
  <img width="928" height="909" alt="스크린샷 2026-01-26 174046" src="https://github.com/user-attachments/assets/c95aaf7c-ee5c-4cf7-896d-2dd0e3565e04" />

- 상품 등록 결과
  <img width="1585" height="427" alt="스크린샷 2026-01-26 174011" src="https://github.com/user-attachments/assets/9635fdda-fead-4ebe-b4d1-097d3c040f42" />

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
