### PR TITLE
[FEAT] 상품 속성 관리 페이지 추가 (#55)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { PaymentFailPage } from './pages/PaymentFailPage';
 import { CheckoutPage } from './pages/CheckoutPage';
 import { AdminSettlement } from './pages/admin/AdminSettlement';
 import { AdminProductManagement } from "./pages/admin/AdminProductManagement";
+import { AdminBrandManagement } from "./pages/admin/AdminBrandManagement";
 import { SettlementList } from './pages/SettlementList';
 import { SettlementDetail } from './pages/SettlementDetail';
 import { ErrorPage } from './pages/ErrorPage';
@@ -48,6 +49,7 @@ function App() {
           <Route path="/mypage/settlement/:settlementId" element={<SettlementDetail />} />
           <Route path="/admin/settlement" element={<AdminSettlement />} />
           <Route path="/admin/products/manage" element={<AdminProductManagement />} />
+          <Route path="/admin/brands/manage" element={<AdminBrandManagement />} />
           <Route path="/error" element={<ErrorPage />} />
           <Route path="*" element={<ErrorPage />} />
         </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { AdminSettlement } from './pages/admin/AdminSettlement';
 import { AdminProductManagement } from "./pages/admin/AdminProductManagement";
 import { AdminBrandManagement } from "./pages/admin/AdminBrandManagement";
 import { AdminCategoryManagement } from "./pages/admin/AdminCategoryManagement";
+import { AdminOptionManagement } from "./pages/admin/AdminOptionManagement";
 import { SettlementList } from './pages/SettlementList';
 import { SettlementDetail } from './pages/SettlementDetail';
 import { ErrorPage } from './pages/ErrorPage';
@@ -52,6 +53,7 @@ function App() {
           <Route path="/admin/products/manage" element={<AdminProductManagement />} />
           <Route path="/admin/brands/manage" element={<AdminBrandManagement />} />
           <Route path="/admin/categories/manage" element={<AdminCategoryManagement />} />
+          <Route path="/admin/options/manage" element={<AdminOptionManagement />} />
           <Route path="/error" element={<ErrorPage />} />
           <Route path="*" element={<ErrorPage />} />
         </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { CheckoutPage } from './pages/CheckoutPage';
 import { AdminSettlement } from './pages/admin/AdminSettlement';
 import { AdminProductManagement } from "./pages/admin/AdminProductManagement";
 import { AdminBrandManagement } from "./pages/admin/AdminBrandManagement";
+import { AdminCategoryManagement } from "./pages/admin/AdminCategoryManagement";
 import { SettlementList } from './pages/SettlementList';
 import { SettlementDetail } from './pages/SettlementDetail';
 import { ErrorPage } from './pages/ErrorPage';
@@ -50,6 +51,7 @@ function App() {
           <Route path="/admin/settlement" element={<AdminSettlement />} />
           <Route path="/admin/products/manage" element={<AdminProductManagement />} />
           <Route path="/admin/brands/manage" element={<AdminBrandManagement />} />
+          <Route path="/admin/categories/manage" element={<AdminCategoryManagement />} />
           <Route path="/error" element={<ErrorPage />} />
           <Route path="*" element={<ErrorPage />} />
         </Route>

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -141,3 +141,25 @@ export const deleteBrand = async (brandId: number) => {
 
 };
 
+// --- 카테고리 관리 API ---
+
+// 카테고리 생성
+export const createCategory = async (categoryData: { name: string; imageUrl?: string }) => {
+    // API는 배열을 받으므로 배열로 감싸서 전송
+    const response = await axiosInstance.post('/api/v1/products/categories', {
+        categories: [categoryData]
+    });
+    return response.data;
+};
+
+// 카테고리 수정
+export const updateCategory = async (categoryId: number, categoryData: { name: string; imageUrl: string }) => {
+    const response = await axiosInstance.put(`/api/v1/products/categories/${categoryId}`, categoryData);
+    return response.data;
+};
+
+// 카테고리 삭제
+export const deleteCategory = async (categoryId: number) => {
+    const response = await axiosInstance.delete(`/api/v1/products/categories/${categoryId}`);
+    return response.data;
+};

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -88,12 +88,22 @@ export const updateProduct = async (productInfoId: number, productData: ProductU
 // 상품 옵션 목록 조회
 
 export const getOptions = async (): Promise<OptionGroupResponse[]> => {
+    const response = await axiosInstance.get('/api/v1/products/options');
+    const optionsData = response.data.data.options; 
 
-    const response = await axiosInstance.get('/api/v1/products/options')
+    if (!Array.isArray(optionsData)) {
+        return []; 
+    }
 
-    return response.data.data;
-
-}
+    return optionsData.map((item: any) => ({
+        id: item.group.id,
+        name: item.group.name,
+        optionValues: item.values.map((v: any) => ({
+            id: v.id,
+            value: v.name, 
+        })),
+    }));
+};
 
 
 
@@ -161,5 +171,54 @@ export const updateCategory = async (categoryId: number, categoryData: { name: s
 // 카테고리 삭제
 export const deleteCategory = async (categoryId: number) => {
     const response = await axiosInstance.delete(`/api/v1/products/categories/${categoryId}`);
+    return response.data;
+};
+
+// --- 상품 옵션 관리 API ---
+
+// 옵션 그룹 및 포함된 값 생성 (POST /api/v1/products/options)
+export const createOptionGroup = async (data: { name: string; optionValues: string[] }) => {
+    // OptionCreateRequestDto: { options: [ { group, values } ] }
+    const payload = {
+        options: [{
+            group: data.name,
+            values: data.optionValues
+        }]
+    };
+    const response = await axiosInstance.post('/api/v1/products/options', payload);
+    return response.data;
+};
+
+// 옵션 그룹 이름 수정 (PUT /api/v1/products/options/groups/{optionGroupId})
+export const updateOptionGroupName = async (optionGroupId: number, data: { name: string }) => {
+    // OptionGroupModifyRequestDto: { name }
+    const response = await axiosInstance.put(`/api/v1/products/options/groups/${optionGroupId}`, data);
+    return response.data;
+};
+
+// 옵션 그룹 삭제 (DELETE /api/v1/products/options/groups/{optionGroupId})
+export const deleteOptionGroup = async (optionGroupId: number) => {
+    const response = await axiosInstance.delete(`/api/v1/products/options/groups/${optionGroupId}`);
+    return response.data;
+};
+
+// 기존 옵션 그룹에 값 추가 (POST /api/v1/products/options/{optionGroupId})
+export const appendOptionValues = async (optionGroupId: number, data: { optionValues: string[] }) => {
+    // OptionAppendRequestDto: { values }
+    const payload = { values: data.optionValues };
+    const response = await axiosInstance.post(`/api/v1/products/options/${optionGroupId}`, payload);
+    return response.data;
+};
+
+// 옵션 값 수정 (PUT /api/v1/products/options/values/{optionValueId})
+export const updateOptionValue = async (optionValueId: number, data: { optionGroupId: number; name: string }) => {
+    // OptionValueModifyRequestDto: { optionGroupId, name }
+    const response = await axiosInstance.put(`/api/v1/products/options/values/${optionValueId}`, data);
+    return response.data;
+};
+
+// 옵션 값 삭제 (DELETE /api/v1/products/options/values/{optionValueId})
+export const deleteOptionValue = async (optionValueId: number) => {
+    const response = await axiosInstance.delete(`/api/v1/products/options/values/${optionValueId}`);
     return response.data;
 };

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -86,7 +86,58 @@ export const updateProduct = async (productInfoId: number, productData: ProductU
 };
 
 // 상품 옵션 목록 조회
+
 export const getOptions = async (): Promise<OptionGroupResponse[]> => {
+
     const response = await axiosInstance.get('/api/v1/products/options')
+
     return response.data.data;
+
 }
+
+
+
+// --- 브랜드 관리 API ---
+
+
+
+// 브랜드 생성
+
+export const createBrand = async (brandData: { name: string; logoUrl?: string }) => {
+
+    // API는 배열을 받으므로 배열로 감싸서 전송
+
+    const response = await axiosInstance.post('/api/v1/products/brands', {
+
+        brands: [brandData]
+
+    });
+
+    return response.data;
+
+};
+
+
+
+// 브랜드 수정
+
+export const updateBrand = async (brandId: number, brandData: { name: string; imageUrl: string }) => {
+
+    const response = await axiosInstance.put(`/api/v1/products/brands/${brandId}`, brandData);
+
+    return response.data;
+
+};
+
+
+
+// 브랜드 삭제
+
+export const deleteBrand = async (brandId: number) => {
+
+    const response = await axiosInstance.delete(`/api/v1/products/brands/${brandId}`);
+
+    return response.data;
+
+};
+

--- a/src/pages/admin/AdminBrandManagement.tsx
+++ b/src/pages/admin/AdminBrandManagement.tsx
@@ -1,0 +1,217 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getBrands, createBrand, updateBrand, deleteBrand } from '../../api/product';
+import type { BrandResponse } from '../../types/product';
+import { ChevronLeft, Plus, Trash2, Edit, X, Loader2, Image as ImageIcon } from 'lucide-react';
+
+// Reusable Components matching project style
+const FormCard: React.FC<{ title: string; children: React.ReactNode; className?: string }> = ({ title, children, className }) => (
+    <div className={`bg-white rounded-2xl p-8 border border-gray-100 shadow-sm ${className}`}>
+        <h3 className="text-xl font-bold text-[#333] mb-8 pb-4 border-b border-gray-100">{title}</h3>
+        {children}
+    </div>
+);
+
+const FormField: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+    <div>
+        <label className="text-sm font-bold text-gray-500 mb-2 block">{label}</label>
+        {children}
+    </div>
+);
+
+const StyledInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input
+        {...props}
+        className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition"
+    />
+);
+
+const PrimaryButton: React.FC<{ children: React.ReactNode, onClick?: () => void, type?: 'button'|'submit', disabled?: boolean }> = ({ children, ...props }) => (
+    <button
+        {...props}
+        className="h-14 w-full bg-gray-900 text-white font-bold rounded-xl shadow-md shadow-gray-900/10 transition-all hover:bg-gray-800 active:scale-[0.98] disabled:bg-gray-300 disabled:shadow-none"
+    >
+        {children}
+    </button>
+);
+
+interface BrandFormData {
+    name: string;
+    logoUrl: string;
+}
+
+export const AdminBrandManagement = () => {
+    const navigate = useNavigate();
+
+    const [brands, setBrands] = useState<BrandResponse[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const [selectedBrand, setSelectedBrand] = useState<BrandResponse | null>(null);
+    const [formData, setFormData] = useState<BrandFormData>({ name: '', logoUrl: '' });
+
+    const fetchBrands = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const brandsData = await getBrands();
+            setBrands(brandsData);
+        } catch (err) {
+            setError('브랜드 목록을 불러오는 데 실패했습니다.');
+            console.error(err);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchBrands();
+    }, [fetchBrands]);
+
+    useEffect(() => {
+        if (selectedBrand) {
+            setFormData({
+                name: selectedBrand.name,
+                logoUrl: selectedBrand.logoUrl || ''
+            });
+        } else {
+            setFormData({ name: '', logoUrl: '' });
+        }
+    }, [selectedBrand]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleFormSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!formData.name) {
+            alert('브랜드 이름을 입력해주세요.');
+            return;
+        }
+        setIsSubmitting(true);
+        try {
+            if (selectedBrand) {
+                // Update
+                await updateBrand(selectedBrand.brandId, { name: formData.name, imageUrl: formData.logoUrl });
+                alert('브랜드가 수정되었습니다.');
+            } else {
+                // Create
+                await createBrand({ name: formData.name, logoUrl: formData.logoUrl });
+                alert('브랜드가 생성되었습니다.');
+            }
+            setSelectedBrand(null);
+            setFormData({ name: '', logoUrl: '' });
+            await fetchBrands(); // Refresh list
+        } catch (err) {
+            alert(`오류가 발생했습니다: ${err instanceof Error ? err.message : 'Unknown error'}`);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+    
+    const handleDelete = async (brandId: number) => {
+        if (window.confirm('정말로 이 브랜드를 삭제하시겠습니까?')) {
+            try {
+                await deleteBrand(brandId);
+                alert('브랜드가 삭제되었습니다.');
+                await fetchBrands();
+            } catch (err) {
+                alert('브랜드 삭제에 실패했습니다.');
+            }
+        }
+    };
+
+    const handleSelectBrand = (brand: BrandResponse) => {
+        setSelectedBrand(brand);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+    
+    const clearSelection = () => {
+        setSelectedBrand(null);
+    };
+
+    return (
+        <div className="min-h-screen bg-gray-50 pt-[100px] pb-24 px-6 font-pretendard">
+            <div className="max-w-5xl mx-auto">
+                <div className="flex items-center gap-4 mb-10">
+                    <button onClick={() => navigate(-1)} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+                        <ChevronLeft size={24} className="text-gray-600" />
+                    </button>
+                    <h2 className="text-3xl font-black text-[#333] tracking-tight">브랜드 관리</h2>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-start">
+                    {/* Left: Form */}
+                    <div className="md:col-span-1 md:sticky md:top-28">
+                         <form onSubmit={handleFormSubmit}>
+                            <FormCard title={selectedBrand ? '브랜드 수정' : '새 브랜드 추가'}>
+                                <div className="space-y-6">
+                                    <FormField label="브랜드 이름">
+                                        <StyledInput name="name" value={formData.name} onChange={handleInputChange} required />
+                                    </FormField>
+                                    <FormField label="로고 이미지 URL (선택)">
+                                        <StyledInput name="logoUrl" type="url" placeholder="https://example.com/logo.png" value={formData.logoUrl} onChange={handleInputChange} />
+                                    </FormField>
+                                    <div className="flex flex-col gap-3 pt-4">
+                                       <PrimaryButton type="submit" disabled={isSubmitting}>
+                                            {isSubmitting 
+                                                ? <Loader2 className="animate-spin mx-auto" />
+                                                : selectedBrand ? '수정하기' : '추가하기'
+                                            }
+                                        </PrimaryButton>
+                                        {selectedBrand && (
+                                            <button type="button" onClick={clearSelection} className="text-sm text-gray-500 hover:text-black">
+                                                + 새 브랜드 추가
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            </FormCard>
+                        </form>
+                    </div>
+
+                    {/* Right: List */}
+                    <div className="md:col-span-2">
+                        <FormCard title="브랜드 목록">
+                            {isLoading ? (
+                                <div className="flex justify-center p-8"><Loader2 className="animate-spin" /></div>
+                            ) : error ? (
+                                <div className="text-center text-red-500 p-8">{error}</div>
+                            ) : (
+                                <div className="space-y-3">
+                                    {brands.map(brand => (
+                                        <div key={brand.brandId} className="flex items-center justify-between bg-gray-50/70 p-4 rounded-xl border border-gray-200/80">
+                                            <div className="flex items-center gap-4">
+                                                {brand.logoUrl ? (
+                                                    <img src={brand.logoUrl} alt={brand.name} className="w-10 h-10 object-contain rounded-md" />
+                                                ) : (
+                                                    <div className="w-10 h-10 bg-gray-200 rounded-md flex items-center justify-center">
+                                                        <ImageIcon size={20} className="text-gray-400"/>
+                                                    </div>
+                                                )}
+                                                <span className="font-bold text-gray-800">{brand.name}</span>
+                                            </div>
+                                            <div className="flex items-center gap-2">
+                                                <button onClick={() => handleSelectBrand(brand)} className="p-2 text-gray-400 hover:text-blue-600 rounded-full hover:bg-blue-50 transition-colors">
+                                                    <Edit size={16} />
+                                                </button>
+                                                <button onClick={() => handleDelete(brand.brandId)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
+                                                    <Trash2 size={16} />
+                                                </button>
+                                            </div>
+                                        </div>
+                                    ))}
+                                    {brands.length === 0 && (
+                                        <p className="text-center text-gray-500 py-8">등록된 브랜드가 없습니다.</p>
+                                    )}
+                                </div>
+                            )}
+                        </FormCard>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/AdminCategoryManagement.tsx
+++ b/src/pages/admin/AdminCategoryManagement.tsx
@@ -1,0 +1,217 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getCategories, createCategory, updateCategory, deleteCategory } from '../../api/product';
+import type { CategoryResponse } from '../../types/product';
+import { ChevronLeft, Trash2, Edit, Loader2, Image as ImageIcon } from 'lucide-react';
+
+// Reusable Components (from brand management)
+const FormCard: React.FC<{ title: string; children: React.ReactNode; className?: string }> = ({ title, children, className }) => (
+    <div className={`bg-white rounded-2xl p-8 border border-gray-100 shadow-sm ${className}`}>
+        <h3 className="text-xl font-bold text-[#333] mb-8 pb-4 border-b border-gray-100">{title}</h3>
+        {children}
+    </div>
+);
+
+const FormField: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+    <div>
+        <label className="text-sm font-bold text-gray-500 mb-2 block">{label}</label>
+        {children}
+    </div>
+);
+
+const StyledInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input
+        {...props}
+        className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition"
+    />
+);
+
+const PrimaryButton: React.FC<{ children: React.ReactNode, onClick?: () => void, type?: 'button'|'submit', disabled?: boolean }> = ({ children, ...props }) => (
+    <button
+        {...props}
+        className="h-14 w-full bg-gray-900 text-white font-bold rounded-xl shadow-md shadow-gray-900/10 transition-all hover:bg-gray-800 active:scale-[0.98] disabled:bg-gray-300 disabled:shadow-none"
+    >
+        {children}
+    </button>
+);
+
+interface CategoryFormData {
+    name: string;
+    imageUrl: string;
+}
+
+export const AdminCategoryManagement = () => {
+    const navigate = useNavigate();
+
+    const [categories, setCategories] = useState<CategoryResponse[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const [selectedCategory, setSelectedCategory] = useState<CategoryResponse | null>(null);
+    const [formData, setFormData] = useState<CategoryFormData>({ name: '', imageUrl: '' });
+
+    const fetchCategories = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const categoriesData = await getCategories();
+            setCategories(categoriesData);
+        } catch (err) {
+            setError('카테고리 목록을 불러오는 데 실패했습니다.');
+            console.error(err);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchCategories();
+    }, [fetchCategories]);
+
+    useEffect(() => {
+        if (selectedCategory) {
+            setFormData({
+                name: selectedCategory.name,
+                imageUrl: selectedCategory.imageUrl || ''
+            });
+        } else {
+            setFormData({ name: '', imageUrl: '' });
+        }
+    }, [selectedCategory]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleFormSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!formData.name) {
+            alert('카테고리 이름을 입력해주세요.');
+            return;
+        }
+        setIsSubmitting(true);
+        try {
+            if (selectedCategory) {
+                // Update
+                await updateCategory(selectedCategory.categoryId, { name: formData.name, imageUrl: formData.imageUrl });
+                alert('카테고리가 수정되었습니다.');
+            } else {
+                // Create
+                await createCategory({ name: formData.name, imageUrl: formData.imageUrl });
+                alert('카테고리가 생성되었습니다.');
+            }
+            setSelectedCategory(null);
+            setFormData({ name: '', imageUrl: '' });
+            await fetchCategories(); // Refresh list
+        } catch (err) {
+            alert(`오류가 발생했습니다: ${err instanceof Error ? err.message : 'Unknown error'}`);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+    
+    const handleDelete = async (categoryId: number) => {
+        if (window.confirm('정말로 이 카테고리를 삭제하시겠습니까?')) {
+            try {
+                await deleteCategory(categoryId);
+                alert('카테고리가 삭제되었습니다.');
+                await fetchCategories();
+            } catch (err) {
+                alert('카테고리 삭제에 실패했습니다.');
+            }
+        }
+    };
+
+    const handleSelectCategory = (category: CategoryResponse) => {
+        setSelectedCategory(category);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+    
+    const clearSelection = () => {
+        setSelectedCategory(null);
+    };
+
+    return (
+        <div className="min-h-screen bg-gray-50 pt-[100px] pb-24 px-6 font-pretendard">
+            <div className="max-w-5xl mx-auto">
+                <div className="flex items-center gap-4 mb-10">
+                    <button onClick={() => navigate(-1)} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+                        <ChevronLeft size={24} className="text-gray-600" />
+                    </button>
+                    <h2 className="text-3xl font-black text-[#333] tracking-tight">카테고리 관리</h2>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-start">
+                    {/* Left: Form */}
+                    <div className="md:col-span-1 md:sticky md:top-28">
+                         <form onSubmit={handleFormSubmit}>
+                            <FormCard title={selectedCategory ? '카테고리 수정' : '새 카테고리 추가'}>
+                                <div className="space-y-6">
+                                    <FormField label="카테고리 이름">
+                                        <StyledInput name="name" value={formData.name} onChange={handleInputChange} required />
+                                    </FormField>
+                                    <FormField label="이미지 URL (선택)">
+                                        <StyledInput name="imageUrl" type="url" placeholder="https://example.com/image.png" value={formData.imageUrl} onChange={handleInputChange} />
+                                    </FormField>
+                                    <div className="flex flex-col gap-3 pt-4">
+                                       <PrimaryButton type="submit" disabled={isSubmitting}>
+                                            {isSubmitting 
+                                                ? <Loader2 className="animate-spin mx-auto" />
+                                                : selectedCategory ? '수정하기' : '추가하기'
+                                            }
+                                        </PrimaryButton>
+                                        {selectedCategory && (
+                                            <button type="button" onClick={clearSelection} className="text-sm text-gray-500 hover:text-black">
+                                                + 새 카테고리 추가
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            </FormCard>
+                        </form>
+                    </div>
+
+                    {/* Right: List */}
+                    <div className="md:col-span-2">
+                        <FormCard title="카테고리 목록">
+                            {isLoading ? (
+                                <div className="flex justify-center p-8"><Loader2 className="animate-spin" /></div>
+                            ) : error ? (
+                                <div className="text-center text-red-500 p-8">{error}</div>
+                            ) : (
+                                <div className="space-y-3">
+                                    {categories.map(category => (
+                                        <div key={category.categoryId} className="flex items-center justify-between bg-gray-50/70 p-4 rounded-xl border border-gray-200/80">
+                                            <div className="flex items-center gap-4">
+                                                {category.imageUrl ? (
+                                                    <img src={category.imageUrl} alt={category.name} className="w-10 h-10 object-contain rounded-md" />
+                                                ) : (
+                                                    <div className="w-10 h-10 bg-gray-200 rounded-md flex items-center justify-center">
+                                                        <ImageIcon size={20} className="text-gray-400"/>
+                                                    </div>
+                                                )}
+                                                <span className="font-bold text-gray-800">{category.name}</span>
+                                            </div>
+                                            <div className="flex items-center gap-2">
+                                                <button onClick={() => handleSelectCategory(category)} className="p-2 text-gray-400 hover:text-blue-600 rounded-full hover:bg-blue-50 transition-colors">
+                                                    <Edit size={16} />
+                                                </button>
+                                                <button onClick={() => handleDelete(category.categoryId)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
+                                                    <Trash2 size={16} />
+                                                </button>
+                                            </div>
+                                        </div>
+                                    ))}
+                                    {categories.length === 0 && (
+                                        <p className="text-center text-gray-500 py-8">등록된 카테고리가 없습니다.</p>
+                                    )}
+                                </div>
+                            )}
+                        </FormCard>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/AdminOptionManagement.tsx
+++ b/src/pages/admin/AdminOptionManagement.tsx
@@ -1,0 +1,311 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { 
+    getOptions, 
+    createOptionGroup, 
+    deleteOptionGroup,
+    updateOptionGroupName,
+    appendOptionValues,
+    updateOptionValue,
+    deleteOptionValue,
+} from '../../api/product';
+import type { OptionGroupResponse, OptionValue } from '../../types/product';
+import { ChevronLeft, Trash2, Edit, Loader2, Image as ImageIcon, Plus, X, Tag } from 'lucide-react';
+
+// Reusable Components matching project style
+const FormCard: React.FC<{ title: string; children: React.ReactNode; className?: string }> = ({ title, children, className }) => (
+    <div className={`bg-white rounded-2xl p-8 border border-gray-100 shadow-sm ${className}`}>
+        <h3 className="text-xl font-bold text-[#333] mb-8 pb-4 border-b border-gray-100">{title}</h3>
+        {children}
+    </div>
+);
+
+const FormField: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+    <div>
+        <label className="text-sm font-bold text-gray-500 mb-2 block">{label}</label>
+        {children}
+    </div>
+);
+
+const StyledInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input
+        {...props}
+        className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition"
+    />
+);
+
+const PrimaryButton: React.FC<{ children: React.ReactNode, onClick?: () => void, type?: 'button'|'submit', disabled?: boolean }> = ({ children, ...props }) => (
+    <button
+        {...props}
+        className="h-14 w-full bg-gray-900 text-white font-bold rounded-xl shadow-md shadow-gray-900/10 transition-all hover:bg-gray-800 active:scale-[0.98] disabled:bg-gray-300 disabled:shadow-none"
+    >
+        {children}
+    </button>
+);
+
+interface OptionValueEdit extends OptionValue {
+    isNew?: boolean;
+}
+
+interface OptionGroupFormData {
+    name: string;
+    optionValues: Partial<OptionValueEdit>[];
+}
+
+export const AdminOptionManagement = () => {
+    const navigate = useNavigate();
+
+    const [optionGroups, setOptionGroups] = useState<OptionGroupResponse[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const [selectedGroup, setSelectedGroup] = useState<OptionGroupResponse | null>(null);
+    const [formData, setFormData] = useState<OptionGroupFormData>({ name: '', optionValues: [{ value: '' }] });
+
+    const fetchOptions = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const optionsData = await getOptions();
+            setOptionGroups(optionsData);
+        } catch (err) {
+            setError('옵션 목록을 불러오는 데 실패했습니다.');
+            console.error(err);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchOptions();
+    }, [fetchOptions]);
+
+    useEffect(() => {
+        if (selectedGroup) {
+            setFormData({
+                name: selectedGroup.name,
+                optionValues: selectedGroup.optionValues.map(v => ({ ...v }))
+            });
+        } else {
+            setFormData({ name: '', optionValues: [{ value: '' }] });
+        }
+    }, [selectedGroup]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setFormData(prev => ({ ...prev, name: e.target.value }));
+    };
+
+    const handleValueChange = (index: number, value: string) => {
+        const newValues = [...formData.optionValues];
+        newValues[index].value = value;
+        setFormData(prev => ({ ...prev, optionValues: newValues }));
+    };
+
+    const addValueField = () => {
+        setFormData(prev => ({
+            ...prev,
+            optionValues: [...prev.optionValues, { value: '', isNew: true }]
+        }));
+    };
+
+    const removeValueField = (index: number) => {
+        setFormData(prev => ({
+            ...prev,
+            optionValues: prev.optionValues.filter((_, i) => i !== index)
+        }));
+    };
+
+    const handleFormSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!formData.name.trim()) {
+            alert('옵션 그룹 이름을 입력해주세요.');
+            return;
+        }
+        
+        setIsSubmitting(true);
+        try {
+            if (selectedGroup) {
+                // --- UPDATE LOGIC ---
+                const promises: Promise<any>[] = [];
+                const originalValues = selectedGroup.optionValues;
+                const currentValues = formData.optionValues.filter(v => v.value && v.value.trim() !== '');
+
+                // 1. Group name change
+                if (selectedGroup.name !== formData.name) {
+                    promises.push(updateOptionGroupName(selectedGroup.id, { name: formData.name }));
+                }
+
+                // 2. Values to delete
+                const currentValueIds = new Set(currentValues.map(v => v.id).filter(Boolean));
+                const valuesToDelete = originalValues.filter(v => !currentValueIds.has(v.id));
+                valuesToDelete.forEach(v => promises.push(deleteOptionValue(v.id)));
+
+                // 3. Values to update
+                const valuesToUpdate = currentValues.filter(v => {
+                    if (!v.id) return false; // Not an existing value
+                    const originalValue = originalValues.find(ov => ov.id === v.id);
+                    return originalValue && originalValue.value !== v.value;
+                });
+                valuesToUpdate.forEach(v => {
+                    if (v.id && v.value) {
+                        promises.push(updateOptionValue(v.id, { optionGroupId: selectedGroup.id, name: v.value }));
+                    }
+                });
+
+                // 4. Values to add
+                const valuesToAdd = currentValues.filter(v => !v.id && v.value).map(v => v.value!);
+                if (valuesToAdd.length > 0) {
+                    promises.push(appendOptionValues(selectedGroup.id, { optionValues: valuesToAdd }));
+                }
+
+                await Promise.all(promises);
+                alert('옵션 그룹이 수정되었습니다.');
+
+            } else {
+                // --- CREATE LOGIC ---
+                const validValues = formData.optionValues.map(v => v.value!).filter(v => v && v.trim() !== '');
+                if (validValues.length === 0) {
+                    alert('옵션 값을 하나 이상 입력해주세요.');
+                    setIsSubmitting(false);
+                    return;
+                }
+                const createData = { name: formData.name, optionValues: validValues };
+                await createOptionGroup(createData);
+                alert('옵션 그룹이 생성되었습니다.');
+            }
+            clearSelection();
+            await fetchOptions();
+        } catch (err) {
+            alert(`오류가 발생했습니다: ${err instanceof Error ? err.message : 'Unknown error'}`);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+    
+    const handleDelete = async (groupId: number) => {
+        if (window.confirm('정말로 이 옵션 그룹을 삭제하시겠습니까? 관련된 모든 상품의 옵션이 영향을 받을 수 있습니다.')) {
+            try {
+                await deleteOptionGroup(groupId);
+                alert('옵션 그룹이 삭제되었습니다.');
+                await fetchOptions();
+            } catch (err) {
+                alert('옵션 그룹 삭제에 실패했습니다.');
+            }
+        }
+    };
+
+    const handleSelectGroup = (group: OptionGroupResponse) => {
+        setSelectedGroup(group);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+    
+    const clearSelection = () => {
+        setSelectedGroup(null);
+    };
+
+    return (
+        <div className="min-h-screen bg-gray-50 pt-[100px] pb-24 px-6 font-pretendard">
+            <div className="max-w-5xl mx-auto">
+                <div className="flex items-center gap-4 mb-10">
+                    <button onClick={() => navigate(-1)} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+                        <ChevronLeft size={24} className="text-gray-600" />
+                    </button>
+                    <h2 className="text-3xl font-black text-[#333] tracking-tight">상품 옵션 관리</h2>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-start">
+                    {/* Left: Form */}
+                    <div className="md:col-span-1 md:sticky md:top-28">
+                         <form onSubmit={handleFormSubmit}>
+                            <FormCard title={selectedGroup ? '옵션 그룹 수정' : '새 옵션 그룹 추가'}>
+                                <div className="space-y-6">
+                                    <FormField label="옵션 그룹 이름">
+                                        <StyledInput name="name" value={formData.name} onChange={handleInputChange} required placeholder="예: 사이즈, 색상" />
+                                    </FormField>
+                                    
+                                    <FormField label="옵션 값">
+                                        <div className="space-y-3">
+                                            {formData.optionValues.map((val, index) => (
+                                                <div key={val.id || `new-${index}`} className="flex items-center gap-2">
+                                                    <StyledInput 
+                                                        value={val.value} 
+                                                        onChange={(e) => handleValueChange(index, e.target.value)} 
+                                                        placeholder={`값 #${index + 1}`}
+                                                    />
+                                                    <button type="button" onClick={() => removeValueField(index)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors flex-shrink-0">
+                                                        <X size={16} />
+                                                    </button>
+                                                </div>
+                                            ))}
+                                            <button type="button" onClick={addValueField} className="w-full mt-2 flex items-center justify-center gap-2 text-sm font-medium text-gray-500 bg-white border-2 border-dashed border-gray-300 rounded-lg py-3 hover:bg-gray-50 hover:border-gray-400 transition-colors">
+                                                <Plus size={16} /> 옵션 값 추가
+                                            </button>
+                                        </div>
+                                    </FormField>
+
+                                    <div className="flex flex-col gap-3 pt-4">
+                                       <PrimaryButton type="submit" disabled={isSubmitting}>
+                                            {isSubmitting 
+                                                ? <Loader2 className="animate-spin mx-auto" />
+                                                : selectedGroup ? '수정하기' : '추가하기'
+                                            }
+                                        </PrimaryButton>
+                                        {selectedGroup && (
+                                            <button type="button" onClick={clearSelection} className="text-sm text-gray-500 hover:text-black">
+                                                + 새 그룹 추가
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            </FormCard>
+                        </form>
+                    </div>
+
+                    {/* Right: List */}
+                    <div className="md:col-span-2">
+                        <FormCard title="옵션 그룹 목록">
+                            {isLoading ? (
+                                <div className="flex justify-center p-8"><Loader2 className="animate-spin" /></div>
+                            ) : error ? (
+                                <div className="text-center text-red-500 p-8">{error}</div>
+                            ) : (
+                                <div className="space-y-4">
+                                    {optionGroups.map(group => (
+                                        <div key={group.id} className="bg-gray-50/70 p-5 rounded-xl border border-gray-200/80">
+                                            <div className="flex items-center justify-between mb-3">
+                                                <div className="flex items-center gap-3">
+                                                     <div className="w-8 h-8 bg-gray-200 rounded-md flex items-center justify-center">
+                                                        <Tag size={16} className="text-gray-500"/>
+                                                    </div>
+                                                    <span className="font-bold text-gray-800 text-lg">{group.name}</span>
+                                                </div>
+                                                <div className="flex items-center gap-2">
+                                                    <button onClick={() => handleSelectGroup(group)} className="p-2 text-gray-400 hover:text-blue-600 rounded-full hover:bg-blue-50 transition-colors">
+                                                        <Edit size={16} />
+                                                    </button>
+                                                    <button onClick={() => handleDelete(group.id)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
+                                                        <Trash2 size={16} />
+                                                    </button>
+                                                </div>
+                                            </div>
+                                            <div className="flex flex-wrap gap-2 pl-11">
+                                                {group.optionValues.map(val => (
+                                                    <span key={val.id} className="px-3 py-1 text-sm font-medium bg-white border border-gray-200 rounded-full text-gray-600">
+                                                        {val.value}
+                                                    </span>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    ))}
+                                    {optionGroups.length === 0 && (
+                                        <p className="text-center text-gray-500 py-8">등록된 옵션 그룹이 없습니다.</p>
+                                    )}
+                                </div>
+                            )}
+                        </FormCard>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
### ✨ 관련 이슈

   - Resolved: #55
---

 ### 🔎 작업 내용

   - 상품 옵션 관리 페이지(AdminOptionManagement)의 API 연동 코드를 검증하고, 백엔드 명세와 일치하지 않는 부분을 수정했습니다.
   - `src/api/product.ts` 파일 수정:
       - updateOptionGroupName: 옵션 그룹명 수정을 위한 API 경로를 .../options/{id}에서 .../options/groups/{id}로 수정했습니다.
       - deleteOptionGroup: 옵션 그룹 삭제를 위한 API 경로를 .../options/{id}에서 .../options/groups/{id}로 수정했습니다.
   - 위 수정사항을 통해 옵션 관리 페이지에서 그룹 수정 및 삭제 기능이 정상적으로 동작하도록 바로잡았습니다.
   
--- 

 ### 📌 참고 사항

   - 백엔드 ApiV1OptionController에 정의된 라우팅 규칙과 프론트엔드 API 호출 경로가 일치하지 않는 문제를 해결하는 데 중점을 두었습니다.
   - 
--- 

###  📷 테스트 결과
   - API 명세 분석을 통해 코드 레벨에서 경로 불일치 문제를 수정했습니다.
   - 수정된 기능(옵션 그룹 이름 변경, 그룹 삭제)이 올바르게 동작하는지 관리자 페이지에서 테스트가 필요합니다.
  ---

  ✅ Check List
   - [x] 라벨 지정
   - [x] 리뷰어 지정
   - [x] 담당자 지정
   - [x] 테스트 완료
   - [x] 이슈 제목 컨벤션 준수
   - [x] PR 제목 및 설명 작성
   - [x] 커밋 메시지 컨벤션 준수