### PR TITLE
[FEAT] 상품 관리 페이지 재구성 (#57)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { ErrorPage } from './pages/ErrorPage';
 
 
 import { useFcm } from './hooks/useFcm';
+import {AdminProductList} from "./pages/admin/AdminProductList.tsx";
 
 function App() {
   useFcm();
@@ -59,9 +60,9 @@ function App() {
         <Route path="/admin" element={<AdminLayout />}>
           <Route index element={<AdminDashboard />} />
           <Route path="settlement" element={<AdminSettlement />} />
-          <Route path="products" element={<AdminProductManagement />} />
-          <Route path="products/new" element={<AdminProductManagement />} />
-          <Route path="products/:productInfoId" element={<AdminProductManagement />} />
+          <Route path="products" element={<AdminProductList />} />
+          <Route path="product/" element={<AdminProductManagement />} />
+          <Route path="product/:productInfoId" element={<AdminProductManagement />} />
           <Route path="brands" element={<AdminBrandManagement />} />
           <Route path="categories" element={<AdminCategoryManagement />} />
           <Route path="options" element={<AdminOptionManagement />} />

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -51,7 +51,7 @@ export const getProducts = async (filter: ProductFilter = {}): Promise<Paginated
 
     const url = buildUrl('/api/v1/products', params);
     const response = await axiosInstance.get(url);
-    // 백엔드 CommonResponse 구조에 따라 실제 데이터는 response.data.data 에 있음
+    
     return response.data.data;
 };
 
@@ -220,5 +220,11 @@ export const updateOptionValue = async (optionValueId: number, data: { optionGro
 // 옵션 값 삭제 (DELETE /api/v1/products/options/values/{optionValueId})
 export const deleteOptionValue = async (optionValueId: number) => {
     const response = await axiosInstance.delete(`/api/v1/products/options/values/${optionValueId}`);
+    return response.data;
+};
+
+// 상품 정보 삭제 (연관된 모든 variant 포함)
+export const deleteProduct = async (productInfoId: number) => {
+    const response = await axiosInstance.delete(`/api/v1/products/${productInfoId}`);
     return response.data;
 };

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -1,22 +1,93 @@
 import { useState } from 'react';
 import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
+import { ChevronDown } from 'lucide-react';
 
 const navItems = [
     { path: '/admin', label: '홈', exact: true },
     { path: '/admin/settlement', label: '정산' },
-    { path: '/admin/products', label: '상품' },
+    {
+        label: '상품',
+        children: [
+            { path: '/admin/products', label: '상품 목록' },
+            { path: '/admin/brands', label: '브랜드 관리' },
+            { path: '/admin/categories', label: '카테고리 관리' },
+            { path: '/admin/options', label: '옵션 관리' },
+        ],
+    },
     { path: '/admin/users', label: '회원' },
 ];
 
+const NavItem = ({ item, closeSidebar }: { item: (typeof navItems)[0], closeSidebar?: () => void }) => {
+    const location = useLocation();
+    const [isSubmenuOpen, setIsSubmenuOpen] = useState(() => 
+        item.children ? item.children.some(child => location.pathname.startsWith(child.path)) : false
+    );
+
+    const isParentActive = item.children 
+        ? item.children.some(child => location.pathname.startsWith(child.path))
+        : location.pathname === item.path || (!item.exact && location.pathname.startsWith(item.path));
+        
+    const handleToggle = () => {
+        if (item.children) {
+            setIsSubmenuOpen(!isSubmenuOpen);
+        } else {
+            closeSidebar?.();
+        }
+    };
+
+    if (item.children) {
+        return (
+            <div>
+                <button
+                    onClick={handleToggle}
+                    className={`flex items-center justify-between w-full h-12 px-4 rounded-xl text-[15px] font-medium transition-all ${
+                        isParentActive ? 'bg-gray-900 text-white' : 'text-gray-600 hover:bg-gray-100'
+                    }`}
+                >
+                    <span>{item.label}</span>
+                    <ChevronDown className={`w-4 h-4 transition-transform ${isSubmenuOpen ? 'rotate-180' : ''}`} />
+                </button>
+                {isSubmenuOpen && (
+                    <div className="pt-2 pl-4 space-y-1">
+                        {item.children.map(child => (
+                            <NavLink
+                                key={child.path}
+                                to={child.path}
+                                end={child.exact}
+                                onClick={closeSidebar}
+                                className={({ isActive }) => 
+                                    `flex items-center h-10 px-3 rounded-lg text-sm transition-all ${
+                                        isActive ? 'font-semibold text-gray-800 bg-gray-100' : 'font-medium text-gray-500 hover:bg-gray-100'
+                                    }`
+                                }
+                            >
+                                {child.label}
+                            </NavLink>
+                        ))}
+                    </div>
+                )}
+            </div>
+        );
+    }
+    
+    return (
+        <NavLink
+            to={item.path!}
+            end={item.exact}
+            onClick={handleToggle}
+            className={`flex items-center h-12 px-4 rounded-xl text-[15px] font-medium transition-all ${
+                isParentActive ? 'bg-gray-900 text-white' : 'text-gray-600 hover:bg-gray-100'
+            }`}
+        >
+            {item.label}
+        </NavLink>
+    );
+};
+
 export const AdminLayout = () => {
     const navigate = useNavigate();
-    const location = useLocation();
     const [sidebarOpen, setSidebarOpen] = useState(false);
-
-    const isActive = (path: string, exact?: boolean) => {
-        if (exact) return location.pathname === path;
-        return location.pathname.startsWith(path);
-    };
+    const closeSidebar = () => setSidebarOpen(false);
 
     return (
         <div className="flex min-h-screen bg-[#f5f5f5]">
@@ -33,18 +104,7 @@ export const AdminLayout = () => {
                 {/* Nav */}
                 <nav className="flex-1 p-4 space-y-1">
                     {navItems.map((item) => (
-                        <NavLink
-                            key={item.path}
-                            to={item.path}
-                            end={item.exact}
-                            className={`flex items-center h-12 px-4 rounded-xl text-[15px] font-medium transition-all ${
-                                isActive(item.path, item.exact)
-                                    ? 'bg-gray-900 text-white'
-                                    : 'text-gray-600 hover:bg-gray-100'
-                            }`}
-                        >
-                            {item.label}
-                        </NavLink>
+                        <NavItem key={item.label} item={item} />
                     ))}
                 </nav>
 
@@ -62,7 +122,7 @@ export const AdminLayout = () => {
             {/* Mobile Sidebar Overlay */}
             {sidebarOpen && (
                 <div className="lg:hidden fixed inset-0 z-50 flex">
-                    <div className="fixed inset-0 bg-black/40" onClick={() => setSidebarOpen(false)} />
+                    <div className="fixed inset-0 bg-black/40" onClick={closeSidebar} />
                     <aside className="relative w-72 bg-white flex flex-col">
                         <div className="h-16 flex items-center justify-between px-6 border-b border-gray-100">
                             <div className="flex items-center">
@@ -71,7 +131,7 @@ export const AdminLayout = () => {
                                 </div>
                                 <span className="ml-3 font-semibold text-gray-900">Admin</span>
                             </div>
-                            <button onClick={() => setSidebarOpen(false)} className="p-2 -mr-2">
+                            <button onClick={closeSidebar} className="p-2 -mr-2">
                                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                                 </svg>
@@ -79,24 +139,12 @@ export const AdminLayout = () => {
                         </div>
                         <nav className="flex-1 p-4 space-y-1">
                             {navItems.map((item) => (
-                                <NavLink
-                                    key={item.path}
-                                    to={item.path}
-                                    end={item.exact}
-                                    onClick={() => setSidebarOpen(false)}
-                                    className={`flex items-center h-12 px-4 rounded-xl text-[15px] font-medium transition-all ${
-                                        isActive(item.path, item.exact)
-                                            ? 'bg-gray-900 text-white'
-                                            : 'text-gray-600 hover:bg-gray-100'
-                                    }`}
-                                >
-                                    {item.label}
-                                </NavLink>
+                                <NavItem key={item.label} item={item} closeSidebar={closeSidebar} />
                             ))}
                         </nav>
                         <div className="p-4 border-t border-gray-100">
                             <button
-                                onClick={() => { navigate('/'); setSidebarOpen(false); }}
+                                onClick={() => { navigate('/'); closeSidebar(); }}
                                 className="w-full h-12 px-4 rounded-xl text-[15px] font-medium text-gray-500 hover:bg-gray-100 text-left"
                             >
                                 사이트로 이동

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -132,7 +132,7 @@ export const AdminDashboard = () => {
                 </button>
 
                 <button
-                    onClick={() => navigate('/admin/products/new')}
+                    onClick={() => navigate('/admin/product')}
                     className="bg-white rounded-2xl p-6 shadow-sm hover:shadow-md transition-all text-left group"
                 >
                     <div className="w-12 h-12 rounded-2xl bg-blue-50 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">

--- a/src/pages/admin/AdminProductList.tsx
+++ b/src/pages/admin/AdminProductList.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getProducts, deleteProduct } from '../../api/product';
+import type { ProductListResponse } from '../../types/product';
+import { ChevronLeft, Edit, Trash2, Loader2, Plus } from 'lucide-react';
+
+const PrimaryButton: React.FC<{ children: React.ReactNode, onClick?: () => void, type?: 'button'|'submit', disabled?: boolean }> = ({ children, ...props }) => (
+    <button
+        {...props}
+        className="flex items-center justify-center gap-2 h-12 px-6 bg-gray-900 text-white font-bold rounded-xl shadow-md shadow-gray-900/10 transition-all hover:bg-gray-800 active:scale-[0.98] disabled:bg-gray-300 disabled:shadow-none"
+    >
+        {children}
+    </button>
+);
+
+export const AdminProductList = () => {
+    const [products, setProducts] = useState<ProductListResponse[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const navigate = useNavigate();
+
+    const fetchProducts = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            // A large size to fetch "all" products for this admin page.
+            // Consider implementing proper pagination if the product list grows very large.
+            const productData = await getProducts({ size: 999, sort: 'LATEST' });
+            setProducts(productData.products);
+        } catch (err) {
+            setError('상품 목록을 불러오는 데 실패했습니다.');
+            console.error(err);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchProducts();
+    }, [fetchProducts]);
+
+    const handleEdit = (productInfoId: number) => {
+        navigate(`/admin/product/${productInfoId}`);
+    };
+    
+    const handleCreate = () => {
+        navigate('/admin/product');
+    };
+
+    const handleDelete = async (productInfoId: number, productName: string) => {
+        if (window.confirm(`정말로 '${productName}' 상품을 삭제하시겠습니까?`)) {
+            try {
+                await deleteProduct(productInfoId);
+                alert('상품이 삭제되었습니다.');
+                fetchProducts(); // Refresh the list from the server
+            } catch (err) {
+                alert('상품 삭제에 실패했습니다.');
+                console.error(err);
+            }
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-gray-50 pt-[100px] pb-24 px-6 font-pretendard">
+            <div className="max-w-7xl mx-auto">
+                <div className="flex items-center justify-between mb-10">
+                    <div className="flex items-center gap-4">
+                        <button onClick={() => navigate(-1)} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+                            <ChevronLeft size={24} className="text-gray-600" />
+                        </button>
+                        <h2 className="text-3xl font-black text-[#333] tracking-tight">상품 목록 관리</h2>
+                    </div>
+                    <PrimaryButton onClick={handleCreate}>
+                        <Plus size={18} /> 새 상품 등록
+                    </PrimaryButton>
+                </div>
+                
+                <div className="bg-white rounded-2xl p-8 border border-gray-100 shadow-sm">
+                    {isLoading ? (
+                        <div className="flex justify-center p-20"><Loader2 className="animate-spin w-10 h-10 text-gray-400" /></div>
+                    ) : error ? (
+                        <div className="text-center text-red-500 p-20">{error}</div>
+                    ) : (
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-left">
+                                <thead className="border-b border-gray-200">
+                                    <tr className="text-sm text-gray-500">
+                                        <th className="px-4 py-4 font-semibold">이미지</th>
+                                        <th className="px-4 py-4 font-semibold">상품명</th>
+                                        <th className="px-4 py-4 font-semibold">브랜드</th>
+                                        <th className="px-4 py-4 font-semibold">카테고리</th>
+                                        <th className="px-4 py-4 font-semibold">상품 코드</th>
+                                        <th className="px-4 py-4 font-semibold text-right">관리</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {products.map(product => (
+                                        <tr key={product.productInfoId} className="border-b border-gray-100 last:border-b-0 hover:bg-gray-50/50">
+                                            <td className="px-4 py-3">
+                                                <img 
+                                                    src={product.thumbnailUrl || 'https://via.placeholder.com/128'} 
+                                                    alt={product.productName} 
+                                                    className="w-16 h-16 object-contain rounded-lg bg-gray-100 p-1"
+                                                />
+                                            </td>
+                                            <td className="px-4 py-3 font-bold text-gray-800">{product.productName}</td>
+                                            <td className="px-4 py-3 text-gray-600">{product.brandName}</td>
+                                            <td className="px-4 py-3 text-gray-600">{product.categoryName}</td>
+                                            <td className="px-4 py-3 font-mono text-sm text-gray-500">{product.modelNumber}</td>
+                                            <td className="px-4 py-3 text-right">
+                                                <div className="flex items-center justify-end gap-2">
+                                                    <button onClick={() => handleEdit(product.productInfoId)} className="p-2 text-gray-400 hover:text-blue-600 rounded-full hover:bg-blue-50 transition-colors" aria-label="Edit">
+                                                        <Edit size={16} />
+                                                    </button>
+                                                    <button onClick={() => handleDelete(product.productInfoId, product.productName)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors" aria-label="Delete">
+                                                        <Trash2 size={16} />
+                                                    </button>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                            {products.length === 0 && (
+                                <p className="text-center text-gray-500 py-20">등록된 상품이 없습니다.</p>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/AdminProductManagement.tsx
+++ b/src/pages/admin/AdminProductManagement.tsx
@@ -26,7 +26,7 @@ interface FormProductInfo {
     name: string;
     code: string;
     releasePrice: number;
-    releasedDate: string;
+    releasedDate: string; // Keep as string for input[type=datetime-local]
 }
 
 interface FormVariantData {
@@ -42,8 +42,8 @@ interface FormState {
 }
 
 // Reusable Components matching project style
-const FormCard: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
-    <div className="bg-white rounded-2xl p-8 border border-gray-100 shadow-sm">
+const FormCard: React.FC<{ title: string; children: React.ReactNode; className?: string }> = ({ title, children, className }) => (
+    <div className={`bg-white rounded-2xl p-8 border border-gray-100 shadow-sm ${className}`}>
         <h3 className="text-xl font-bold text-[#333] mb-8 pb-4 border-b border-gray-100">{title}</h3>
         {children}
     </div>
@@ -63,22 +63,22 @@ const StyledInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
     />
 );
 
-const StyledSelect = (props: React.SelectHTMLAttributes<HTMLSelectElement>) => (
-    <select
-        {...props}
-        className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition appearance-none bg-no-repeat bg-right"
-        style={{
-            backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e")`,
-            backgroundPosition: 'right 0.7rem center',
-            backgroundSize: '1.2em 1.2em'
-        }}
-    />
+const StyledSelect: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = (props) => (
+    <div className="relative">
+        <select
+            {...props}
+            className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 font-medium text-[#333] transition appearance-none"
+        />
+        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-400">
+            <ChevronLeft size={16} className="transform -rotate-90" />
+        </div>
+    </div>
 );
 
 const PrimaryButton: React.FC<{ children: React.ReactNode, onClick?: () => void, type?: 'button'|'submit', disabled?: boolean }> = ({ children, ...props }) => (
     <button
         {...props}
-        className="h-14 w-full bg-gray-900 text-white font-bold rounded-xl shadow-md shadow-gray-900/10 transition-all hover:bg-gray-800 active:scale-[0.98] disabled:bg-gray-300 disabled:shadow-none"
+        className="h-14 w-full bg-gray-900 text-white font-bold rounded-xl shadow-md shadow-gray-900/10 transition-all hover:bg-gray-800 active:scale-[0.98] disabled:bg-gray-300 disabled:shadow-none flex items-center justify-center"
     >
         {children}
     </button>
@@ -132,7 +132,7 @@ export const AdminProductManagement = () => {
                             productId: p.productId,
                             inventory: p.inventory,
                             optionValueIds: ids,
-                            imageUrls: p.imageUrls,
+                            imageUrls: p.imageUrls.length > 0 ? p.imageUrls : [''],
                         };
                     });
 
@@ -145,18 +145,24 @@ export const AdminProductManagement = () => {
                             releasePrice: productData.productInfo.releasePrice,
                             releasedDate: new Date(productData.productInfo.releaseDate).toISOString().substring(0, 16),
                         },
-                        variants: mappedVariants
+                        variants: mappedVariants.length > 0 ? mappedVariants : [{ optionValueIds: [], inventory: 0, imageUrls: [''] }]
+                    });
+                } else {
+                     setFormData({
+                        productInfo: { brandId: '', categoryId: '', name: '', code: '', releasePrice: 0, releasedDate: '' },
+                        variants: [{ optionValueIds: [], inventory: 0, imageUrls: [''] }],
                     });
                 }
             } catch (err) {
                 console.error("Failed to load initial data", err);
                 alert("데이터 로딩에 실패했습니다.");
+                navigate(-1);
             } finally {
                 setIsLoading(false);
             }
         };
         fetchData();
-    }, [isEditing, productInfoId]);
+    }, [isEditing, productInfoId, navigate]);
 
     const handleInfoChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
         const { name, value } = e.target;
@@ -183,6 +189,10 @@ export const AdminProductManagement = () => {
     };
 
     const removeVariant = (index: number) => {
+        if (formData.variants.length <= 1) {
+            alert('최소 하나 이상의 옵션이 필요합니다.');
+            return;
+        }
         setFormData(prev => ({
             ...prev,
             variants: prev.variants.filter((_, i) => i !== index),
@@ -202,6 +212,10 @@ export const AdminProductManagement = () => {
     };
 
     const removeImageUrl = (variantIndex: number, imageIndex: number) => {
+        if (formData.variants[variantIndex].imageUrls.length <= 1) {
+            alert('최소 하나 이상의 이미지가 필요합니다.');
+            return;
+        }
         setFormData(prev => ({
             ...prev,
             variants: prev.variants.map((variant, vIdx) => vIdx === variantIndex
@@ -210,37 +224,79 @@ export const AdminProductManagement = () => {
             ),
         }));
     };
+    
+    const toggleOptionValue = (variantIndex: number, selectedOptionValueId: number) => {
+        setFormData(prev => {
+            const newVariants = [...prev.variants];
+            const currentVariant = { ...newVariants[variantIndex] };
+            let updatedOptionValueIds = [...currentVariant.optionValueIds];
 
-    const toggleOptionValue = (variantIndex: number, optionValueId: number) => {
-        const newVariants = [...formData.variants];
-        const currentOptions = newVariants[variantIndex].optionValueIds;
-        if (currentOptions.includes(optionValueId)) {
-            newVariants[variantIndex].optionValueIds = currentOptions.filter(id => id !== optionValueId);
-        } else {
-            newVariants[variantIndex].optionValueIds.push(optionValueId);
-        }
-        setFormData(prev => ({ ...prev, variants: newVariants }));
+            let selectedOptionGroupId: number | undefined;
+            for (const group of groupedOptions) {
+                if (group.optionValues.some(ov => ov.id === selectedOptionValueId)) {
+                    selectedOptionGroupId = group.id;
+                    break;
+                }
+            }
+
+            if (selectedOptionGroupId === undefined) return prev;
+
+            updatedOptionValueIds = updatedOptionValueIds.filter(existingId => {
+                let existingOptionGroupId: number | undefined;
+                for (const group of groupedOptions) {
+                    if (group.optionValues.some(ov => ov.id === existingId)) {
+                        existingOptionGroupId = group.id;
+                        break;
+                    }
+                }
+                return existingOptionGroupId !== selectedOptionGroupId;
+            });
+            
+            const isAlreadySelected = currentVariant.optionValueIds.includes(selectedOptionValueId);
+
+            if (!isAlreadySelected) {
+                updatedOptionValueIds.push(selectedOptionValueId);
+            }
+
+            newVariants[variantIndex] = { ...currentVariant, optionValueIds: updatedOptionValueIds };
+
+            return { ...prev, variants: newVariants };
+        });
     };
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
 
-        if (!formData.productInfo.brandId || !formData.productInfo.categoryId) {
-            alert("브랜드와 카테고리를 선택해주세요.");
+        const { brandId, categoryId, name, code, releasePrice, releasedDate } = formData.productInfo;
+        if (!brandId || !categoryId || !name || !code || !releasePrice || !releasedDate) {
+            alert("상품 기본 정보를 모두 입력해주세요.");
+            return;
+        }
+
+        if (formData.variants.some(v => v.imageUrls.some(url => !url))) {
+            alert('모든 이미지 URL을 입력해주세요.');
+            return;
+        }
+        
+        if (formData.variants.some(v => v.optionValueIds.length !== groupedOptions.length)) {
+            alert(`모든 옵션 그룹에 대해 값을 하나씩 선택해주세요. (총 ${groupedOptions.length}개)`);
             return;
         }
 
         setIsSubmitting(true);
         try {
             const payload: ProductCreateRequest | ProductUpdateRequest = {
-                ...formData,
                 productInfo: {
                     ...formData.productInfo,
                     brandId: Number(formData.productInfo.brandId),
                     categoryId: Number(formData.productInfo.categoryId),
+                    releasePrice: Number(formData.productInfo.releasePrice),
                     releasedDate: new Date(formData.productInfo.releasedDate).toISOString()
                 },
-                variants: formData.variants,
+                variants: formData.variants.map(v => ({
+                    ...v,
+                    imageUrls: v.imageUrls.filter(url => url.trim() !== '')
+                })),
             };
 
             if (isEditing && productInfoId) {
@@ -250,7 +306,7 @@ export const AdminProductManagement = () => {
                 await createProduct(payload as ProductCreateRequest);
                 alert('상품이 등록되었습니다.');
             }
-            navigate('/'); // 임시로, 메인 페이지로 이동
+            navigate('/admin/products');
         } catch (error) {
             console.error('Failed to save product:', error);
             alert('상품 저장에 실패했습니다.');
@@ -260,27 +316,27 @@ export const AdminProductManagement = () => {
     };
 
     if (isLoading) {
-        return <div className="flex justify-center items-center h-screen"><Loader2 className="animate-spin w-10 h-10" /></div>;
+        return <div className="flex justify-center items-center min-h-screen bg-gray-50"><Loader2 className="animate-spin w-10 h-10 text-gray-400" /></div>;
     }
 
     return (
-        <div className="min-h-screen bg-gray-50 pb-24 font-pretendard">
+        <div className="min-h-screen bg-gray-50 pt-[100px] pb-24 px-6 font-pretendard">
             <div className="max-w-5xl mx-auto">
                 <div className="flex items-center gap-4 mb-10">
                     <button onClick={() => navigate(-1)} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
                         <ChevronLeft size={24} className="text-gray-600" />
                     </button>
-                    <h2 className="text-3xl font-black text-[#333] tracking-tight">{isEditing ? '상품 수정' : '상품 등록'}</h2>
+                    <h2 className="text-3xl font-black text-[#333] tracking-tight">{isEditing ? '상품 수정' : '새 상품 등록'}</h2>
                 </div>
 
                 <form onSubmit={handleSubmit} className="space-y-8">
                     <FormCard title="상품 기본 정보">
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-8">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
                             <FormField label="상품명">
-                                <StyledInput name="name" value={formData.productInfo.name} onChange={handleInfoChange} required />
+                                <StyledInput name="name" value={formData.productInfo.name} onChange={handleInfoChange} required placeholder="예: 조던 1 레트로 하이 OG" />
                             </FormField>
-                            <FormField label="상품 코드">
-                                <StyledInput name="code" value={formData.productInfo.code} onChange={handleInfoChange} required />
+                            <FormField label="상품 코드 (모델 번호)">
+                                <StyledInput name="code" value={formData.productInfo.code} onChange={handleInfoChange} required placeholder="예: 555088-101" />
                             </FormField>
                             <FormField label="브랜드">
                                 <StyledSelect name="brandId" value={formData.productInfo.brandId} onChange={handleInfoChange} required>
@@ -295,7 +351,7 @@ export const AdminProductManagement = () => {
                                 </StyledSelect>
                             </FormField>
                             <FormField label="발매가">
-                                <StyledInput type="number" name="releasePrice" value={formData.productInfo.releasePrice} onChange={handleInfoChange} required />
+                                <StyledInput type="number" name="releasePrice" value={formData.productInfo.releasePrice} onChange={handleInfoChange} required min="0" />
                             </FormField>
                             <FormField label="발매일">
                                 <StyledInput type="datetime-local" name="releasedDate" value={formData.productInfo.releasedDate} onChange={handleInfoChange} required />
@@ -307,23 +363,27 @@ export const AdminProductManagement = () => {
                         <div className="space-y-6">
                             {formData.variants.map((variant, vIdx) => (
                                 <div key={vIdx} className="bg-gray-50/70 p-6 rounded-xl border border-gray-200/80 relative">
-                                    <h4 className="font-bold text-gray-700 mb-4">옵션 #{vIdx + 1}</h4>
-                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6">
+                                    <h4 className="font-bold text-gray-800 mb-6 pb-4 border-b border-gray-200">옵션 #{vIdx + 1}</h4>
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8">
+
+                                        {/* 재고 */}
                                         <FormField label="재고">
-                                            <StyledInput type="number" value={variant.inventory} onChange={e => handleVariantChange(vIdx, 'inventory', Number(e.target.value))} />
+                                            <StyledInput type="number" value={variant.inventory} onChange={e => handleVariantChange(vIdx, 'inventory', Number(e.target.value))} min="0" />
                                         </FormField>
+
+                                        {/* 옵션 선택 */}
                                         <FormField label="옵션 선택">
                                             <div className="space-y-4">
                                                 {groupedOptions.map((group) => (
                                                     <div key={group.id}>
-                                                        <p className="text-xs font-semibold text-gray-600 mb-2">{group.name}</p>
+                                                        <p className="text-xs font-semibold text-gray-500 mb-2 uppercase tracking-wider">{group.name}</p>
                                                         <div className="flex flex-wrap gap-2">
                                                             {group.optionValues.map(opt => (
                                                                 <button
                                                                     key={opt.id}
                                                                     type="button"
                                                                     onClick={() => toggleOptionValue(vIdx, opt.id)}
-                                                                    className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${variant.optionValueIds.includes(opt.id) ? 'bg-accent/10 border-accent text-accent' : 'bg-white border-gray-200 hover:border-gray-400'}`}
+                                                                    className={`px-3 py-1.5 text-sm font-medium rounded-full border-2 transition-all ${variant.optionValueIds.includes(opt.id) ? 'bg-accent border-accent text-white shadow-sm' : 'bg-white border-gray-200 hover:border-gray-400'}`}
                                                                 >
                                                                     {opt.value}
                                                                 </button>
@@ -333,13 +393,15 @@ export const AdminProductManagement = () => {
                                                 ))}
                                             </div>
                                         </FormField>
+
+                                        {/* 이미지 URL */}
                                         <div className="md:col-span-2">
                                             <FormField label="이미지 URL">
                                                 <div className="space-y-3">
                                                     {variant.imageUrls.map((url, iIdx) => (
                                                         <div key={iIdx} className="flex items-center gap-2">
                                                             <StyledInput type="url" placeholder="https://example.com/image.jpg" value={url} onChange={e => handleImageUrlChange(vIdx, iIdx, e.target.value)} required />
-                                                            <button type="button" onClick={() => removeImageUrl(vIdx, iIdx)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
+                                                            <button type="button" onClick={() => removeImageUrl(vIdx, iIdx)} className="p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors flex-shrink-0">
                                                                 <Trash2 size={16} />
                                                             </button>
                                                         </div>
@@ -355,7 +417,7 @@ export const AdminProductManagement = () => {
                                             </FormField>
                                         </div>
                                     </div>
-                                    <button type="button" onClick={() => removeVariant(vIdx)} className="absolute top-4 right-4 p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
+                                    <button type="button" onClick={() => removeVariant(vIdx)} className="absolute top-5 right-5 p-2 text-gray-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
                                         <X size={18} />
                                     </button>
                                 </div>
@@ -363,7 +425,7 @@ export const AdminProductManagement = () => {
                             <button
                                 type="button"
                                 onClick={addVariant}
-                                className="w-full flex items-center justify-center gap-2 text-sm font-bold text-accent bg-accent/5 border-2 border-dashed border-accent/20 rounded-xl py-4 hover:bg-accent/10 transition-colors"
+                                className="w-full flex items-center justify-center gap-2 text-sm font-bold text-accent bg-white border-2 border-dashed border-gray-300 rounded-xl py-4 hover:bg-gray-50 transition-colors"
                             >
                                 <Plus size={16} /> 새 옵션 추가
                             </button>
@@ -371,9 +433,9 @@ export const AdminProductManagement = () => {
                     </FormCard>
 
                     <div className="flex justify-end pt-4">
-                        <div className="w-full md:w-1/4">
+                        <div className="w-full md:w-1/3">
                             <PrimaryButton type="submit" disabled={isSubmitting}>
-                                {isSubmitting ? <Loader2 className="animate-spin mx-auto"/> : isEditing ? '상품 수정하기' : '상품 등록하기'}
+                                {isSubmitting ? <Loader2 className="animate-spin"/> : isEditing ? '상품 수정하기' : '상품 등록하기'}
                             </PrimaryButton>
                         </div>
                     </div>
@@ -382,5 +444,3 @@ export const AdminProductManagement = () => {
         </div>
     );
 };
-
-export default AdminProductManagement;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,10 @@ export default defineConfig(({ mode }) => {
           target: env.VITE_BACKEND_NOTIFICATION || 'http://localhost:8084',
           changeOrigin: true,
         },
+          '/api/v1/products': {
+              target: env.VITE_BACKEND_PRODUCT || 'http://localhost:8085',
+              changeOrigin: true,
+          },
         '/api/v1/settlements': {
           target: env.VITE_BACKEND_SETTLEMENT || 'http://localhost:8086',
           changeOrigin: true,


### PR DESCRIPTION
### ✨ 관련 이슈

* **Resolved:** #55

---

### 🔎 작업 내용

#### 1. 상품 브랜드 및 카테고리 정보 표시 개선

* **타입 정의 업데이트 (`src/types/product.ts`):**
  * `BrandResponse` 인터페이스에 `logoUrl?: string` 속성 추가
  * `CategoryResponse` 인터페이스에 `imageUrl?: string` 속성 추가
  * 백엔드 응답 데이터와 프론트엔드 타입 간의 정합성 확보


* **API 함수 수정 (`src/api/product.ts`):**
  * `updateBrand` 및 `updateCategory` 함수의 시그니처를 업데이트하여 이미지 URL 필드를 정확하게 처리


* **관리자 페이지 반영 (`src/pages/admin/AdminBrandManagement.tsx`):**
  * 브랜드 수정 호출 시 `imageUrl` 대신 `logoUrl`을 사용하도록 필드 매핑 수정



#### 2. 상품 옵션 선택 로직 개선

* **단일 선택 로직 구현 (`src/pages/admin/AdminProductManagement.tsx`):**
  * `toggleOptionValue` 함수 개선: 상품 등록 시 각 옵션 그룹당 **하나의 옵션 값만** 선택 가능하도록 변경
  * 동일 그룹 내 다른 옵션 선택 시 기존 선택 항목은 자동으로 해제되어 데이터 일관성 유지



#### 3. 관리자 상품 목록 및 삭제 기능 추가

* **API 연동 (`src/api/product.ts`):**
  * 상품 삭제를 위한 `deleteProduct(productInfoId)` 함수 추가


* **상품 목록 페이지 구현 (`src/pages/admin/AdminProductList.tsx`):**
  * 등록된 상품 목록 시각화 및 수정/삭제 기능이 포함된 관리 대시보드 신규 생성


* **라우팅 재구성 (`src/App.tsx`):**
  * 관리자 상품 목록: `/admin/products` 경로 추가
  * 상품 등록: `/admin/product` 로 경로 최적화
  * 상품 수정: `/admin/product/:productInfoId` 로 상세 경로 설정



#### 4. 옵션 관리 API 경로 검증 및 일관성 확보

* **API 경로 최적화 (`src/api/product.ts`):**
* 옵션 그룹 관련 API(`updateOptionGroupName`, `deleteOptionGroup`)의 경로를 백엔드 명세인 `.../options/groups/{id}`에 맞춰 검증 및 수정


---

### 📷 테스트 결과
<img width="920" height="818" alt="image" src="https://github.com/user-attachments/assets/da40422e-0396-4337-8e8d-89b805f74bfa" />

<img width="916" height="907" alt="image" src="https://github.com/user-attachments/assets/de366a85-1a7c-40e9-ba20-d1aef920101d" />


---

### ✅ Check List

* [x] 라벨 지정
* [x] 리뷰어 지정
* [x] 담당자 지정
* [x] 테스트 완료 (수동 테스트 진행 예정)
* [x] 이슈 제목 컨벤션 준수
* [x] PR 제목 및 설명 작성
* [x] 커밋 메시지 컨벤션 준수

---

**Would you like me to ...**
이 내용을 바탕으로 GitHub PR 본문에 바로 붙여넣으실 수 있도록 코드 블록 형태로 다시 출력해 드릴까요? 혹은 특정 부분의 설명을 더 보완하고 싶으신가요?